### PR TITLE
Add User Signals

### DIFF
--- a/rtl/common/hci_interfaces.sv
+++ b/rtl/common/hci_interfaces.sv
@@ -24,6 +24,7 @@ interface hci_core_intf (
   parameter int unsigned BW = hci_package::DEFAULT_BW; /// Width of a "byte" in bits (default 8)
   parameter int unsigned WW = hci_package::DEFAULT_WW; /// Width of a "word" in bits (default 32)
   parameter int unsigned OW = AW; /// intra-bank offset width, defaults to addr width
+  parameter int unsigned UW = hci_package::DEFAULT_UW; /// User Width
 
   // handshake signals
   logic req;
@@ -36,11 +37,13 @@ interface hci_core_intf (
   logic        [DW-1:0]            data;
   logic        [DW/BW-1:0]         be;
   logic signed [DW/WW-1:0][OW-1:0] boffs; // intra-bank offset, used for bank-restricted scatter/gather
+  logic        [UW-1:0]            user;
 
   // response phase payload
   logic [DW-1:0] r_data;
   logic          r_valid;
   logic          r_opc;
+  logic [UW-1:0] r_user;
 
   modport master (
     output req,
@@ -51,9 +54,11 @@ interface hci_core_intf (
     output be,
     output boffs,
     output lrdy,
+    output user,
     input  r_data,
     input  r_valid,
-    input  r_opc
+    input  r_opc,
+    input  r_user
   );
 
   modport slave (
@@ -65,9 +70,11 @@ interface hci_core_intf (
     input  be,
     input  boffs,
     input  lrdy,
+    input  user,
     output r_data,
     output r_valid,
-    output r_opc
+    output r_opc,
+    output r_user
   );
 
   modport monitor (
@@ -79,9 +86,11 @@ interface hci_core_intf (
     input be,
     input boffs,
     input lrdy,
+    input user,
     input r_data,
     input r_valid,
-    input r_opc
+    input r_opc,
+    input r_user
   );
 
 endinterface // hci_core_intf
@@ -94,6 +103,7 @@ interface hci_mem_intf (
   parameter int unsigned DW = hci_package::DEFAULT_DW; /// Data Width
   parameter int unsigned BW = hci_package::DEFAULT_BW; /// Width of a "byte" in bits (default 8)
   parameter int unsigned IW = 8; /// width of ID
+  parameter int unsigned UW = hci_package::DEFAULT_UW;  /// User Width
 
   // handshake signals
   logic req;
@@ -105,10 +115,12 @@ interface hci_mem_intf (
   logic [DW-1:0]    data;
   logic [DW/BW-1:0] be;
   logic [IW-1:0]    id;
+  logic [UW-1:0]    user;
 
   // response phase payload
   logic [DW-1:0] r_data;
   logic [IW-1:0] r_id;
+  logic [UW-1:0] r_user;
 
   modport master (
     output req,
@@ -118,8 +130,10 @@ interface hci_mem_intf (
     output data,
     output be,
     output id,
+    output user,
     input  r_data,
-    input  r_id
+    input  r_id,
+    input  r_user
   );
 
   modport slave (
@@ -130,8 +144,10 @@ interface hci_mem_intf (
     input  data,
     input  be,
     input  id,
+    input  user,
     output r_data,
-    output r_id
+    output r_id,
+    output r_user
   );
 
   modport monitor (
@@ -142,8 +158,10 @@ interface hci_mem_intf (
     input data,
     input be,
     input id,
+    input user,
     input r_data,
-    input r_id
+    input r_id,
+    input r_user
   );
 
 endinterface // hci_mem_intf

--- a/rtl/common/hci_interfaces.sv
+++ b/rtl/common/hci_interfaces.sv
@@ -19,10 +19,10 @@ interface hci_core_intf (
   input logic clk
 );
 
-  parameter int unsigned DW = hci_package::DEFAULT_DW; /// data width
-  parameter int unsigned AW = hci_package::DEFAULT_AW; /// addr width
-  parameter int unsigned BW = hci_package::DEFAULT_BW; /// width of a "byte" in bits (default 8 of course)
-  parameter int unsigned WW = hci_package::DEFAULT_WW; /// width of a "word" in bits (default 32)
+  parameter int unsigned DW = hci_package::DEFAULT_DW; /// Data Width
+  parameter int unsigned AW = hci_package::DEFAULT_AW; /// Address Width
+  parameter int unsigned BW = hci_package::DEFAULT_BW; /// Width of a "byte" in bits (default 8)
+  parameter int unsigned WW = hci_package::DEFAULT_WW; /// Width of a "word" in bits (default 32)
   parameter int unsigned OW = AW; /// intra-bank offset width, defaults to addr width
 
   // handshake signals
@@ -90,10 +90,10 @@ interface hci_mem_intf (
   input logic clk
 );
 
-  parameter int unsigned AW = 32; /// addr width
-  parameter int unsigned DW = 32; /// data width
-  parameter int unsigned BW = 8;  /// width of a "byte" in bits (default 8 of course)
-  parameter int unsigned IW = 8;  /// width of ID
+  parameter int unsigned AW = hci_package::DEFAULT_AW; /// Address Width
+  parameter int unsigned DW = hci_package::DEFAULT_DW; /// Data Width
+  parameter int unsigned BW = hci_package::DEFAULT_BW; /// Width of a "byte" in bits (default 8)
+  parameter int unsigned IW = 8; /// width of ID
 
   // handshake signals
   logic req;

--- a/rtl/common/hci_package.sv
+++ b/rtl/common/hci_package.sv
@@ -19,6 +19,7 @@ package hci_package;
   parameter int unsigned DEFAULT_AW = 32; // Default Address Width
   parameter int unsigned DEFAULT_BW = 8;  // Default Byte Width
   parameter int unsigned DEFAULT_WW = 32; // Default Word Width
+  parameter int unsigned DEFAULT_UW = 0;  // Default User Width
 
   typedef struct packed {
     logic [1:0] arb_policy;

--- a/rtl/common/hci_package.sv
+++ b/rtl/common/hci_package.sv
@@ -15,10 +15,10 @@
 
 package hci_package;
 
-  parameter int unsigned DEFAULT_DW = 32;
-  parameter int unsigned DEFAULT_AW = 32;
-  parameter int unsigned DEFAULT_BW = 8;
-  parameter int unsigned DEFAULT_WW = 10;
+  parameter int unsigned DEFAULT_DW = 32; // Default Data Width
+  parameter int unsigned DEFAULT_AW = 32; // Default Address Width
+  parameter int unsigned DEFAULT_BW = 8;  // Default Byte Width
+  parameter int unsigned DEFAULT_WW = 32; // Default Word Width
 
   typedef struct packed {
     logic [1:0] arb_policy;

--- a/rtl/core/hci_core_assign.sv
+++ b/rtl/core/hci_core_assign.sv
@@ -29,8 +29,10 @@ module hci_core_assign
   assign tcdm_master.be     = tcdm_slave.be;
   assign tcdm_master.boffs  = tcdm_slave.boffs;
   assign tcdm_master.lrdy   = tcdm_slave.lrdy;
+  assign tcdm_master.user   = tcdm_slave.user;
   assign tcdm_slave.r_data  = tcdm_master.r_data;
   assign tcdm_slave.r_valid = tcdm_master.r_valid;
   assign tcdm_slave.r_opc   = tcdm_master.r_opc;
+  assign tcdm_slave.r_user  = tcdm_master.r_user;
 
 endmodule // hci_core_assign

--- a/rtl/core/hci_core_load_store_mixer.sv
+++ b/rtl/core/hci_core_load_store_mixer.sv
@@ -18,10 +18,10 @@ import hci_package::*;
 
 module hci_core_load_store_mixer
 #(
-  parameter int unsigned DW = 32,
-  parameter int unsigned AW = 32,
-  parameter int unsigned BW = 8,
-  parameter int unsigned WW = 32,
+  parameter int unsigned DW = hci_package::DEFAULT_DW,
+  parameter int unsigned AW = hci_package::DEFAULT_AW,
+  parameter int unsigned BW = hci_package::DEFAULT_BW,
+  parameter int unsigned WW = hci_package::DEFAULT_WW,
   parameter int unsigned OW = 1
 )
 (

--- a/rtl/core/hci_core_load_store_mixer.sv
+++ b/rtl/core/hci_core_load_store_mixer.sv
@@ -22,7 +22,8 @@ module hci_core_load_store_mixer
   parameter int unsigned AW = hci_package::DEFAULT_AW,
   parameter int unsigned BW = hci_package::DEFAULT_BW,
   parameter int unsigned WW = hci_package::DEFAULT_WW,
-  parameter int unsigned OW = 1
+  parameter int unsigned OW = 1,
+  parameter int unsigned UW = hci_package::DEFAULT_UW
 )
 (
   input  logic         clk_i,
@@ -52,9 +53,11 @@ module hci_core_load_store_mixer
   logic [NB_IN_CHAN-1:0][DW/BW-1:0]          in_be;
   logic [NB_IN_CHAN-1:0][DW-1:0]             in_data;
   logic [NB_IN_CHAN-1:0][DW/WW-1:0][OW-1:0]  in_boffs;
+  logic [NB_IN_CHAN-1:0][UW-1:0]             in_user;
   logic [NB_IN_CHAN-1:0][DW-1:0]             in_r_data;
   logic [NB_IN_CHAN-1:0]                     in_r_valid;
   logic [NB_IN_CHAN-1:0]                     in_r_opc;
+  logic [NB_IN_CHAN-1:0][UW-1:0]             in_r_user;
 
   logic [NB_OUT_CHAN-1:0]                    out_req;
   logic [NB_OUT_CHAN-1:0]                    out_gnt;
@@ -64,9 +67,11 @@ module hci_core_load_store_mixer
   logic [NB_OUT_CHAN-1:0][DW/BW-1:0]         out_be;
   logic [NB_OUT_CHAN-1:0][DW-1:0]            out_data;
   logic [NB_OUT_CHAN-1:0][DW/WW-1:0][OW-1:0] out_boffs;
+  logic [NB_OUT_CHAN-1:0][UW-1:0]            out_user;
   logic [NB_OUT_CHAN-1:0][DW-1:0]            out_r_data;
   logic [NB_OUT_CHAN-1:0]                    out_r_valid;
   logic [NB_OUT_CHAN-1:0]                    out_r_opc;
+  logic [NB_OUT_CHAN-1:0][UW-1:0]            out_r_user;
 
   logic [$clog2(NB_IN_CHAN/NB_OUT_CHAN)-1:0]                                              rr_counter;
   logic [NB_OUT_CHAN-1:0][NB_IN_CHAN/NB_OUT_CHAN-1:0][$clog2(NB_IN_CHAN/NB_OUT_CHAN)-1:0] rr_priority;
@@ -97,10 +102,12 @@ module hci_core_load_store_mixer
     assign in_data  [LOAD] = in_load.data;
     assign in_lrdy  [LOAD] = in_load.lrdy;
     assign in_boffs [LOAD] = in_load.boffs;
+    assign in_user  [LOAD] = in_load.user;
     assign in_load.gnt     = in_gnt     [LOAD];
     assign in_load.r_data  = in_r_data  [LOAD];
     assign in_load.r_valid = in_r_valid [LOAD];
     assign in_load.r_opc   = in_r_opc   [LOAD];
+    assign in_load.r_user  = in_r_user  [LOAD];
 
     assign in_req   [STORE] = in_store.req;
     assign in_add   [STORE] = in_store.add;
@@ -109,10 +116,12 @@ module hci_core_load_store_mixer
     assign in_data  [STORE] = in_store.data;
     assign in_lrdy  [STORE] = in_store.lrdy;
     assign in_boffs [STORE] = in_store.boffs;
+    assign in_user  [STORE] = in_store.user;
     assign in_store.gnt     = in_gnt     [STORE];
     assign in_store.r_data  = in_r_data  [STORE];
     assign in_store.r_valid = in_r_valid [STORE];
     assign in_store.r_opc   = in_r_opc   [STORE];
+    assign in_store.r_user  = in_r_user  [STORE];
 
     assign out.req   = out_req   [0];
     assign out.add   = out_add   [0];
@@ -121,10 +130,12 @@ module hci_core_load_store_mixer
     assign out.data  = out_data  [0];
     assign out.lrdy  = out_lrdy  [0];
     assign out.boffs = out_boffs [0];
+    assign out.user  = out_user  [0];
     assign out_gnt     [0] = out.gnt;
     assign out_r_data  [0] = out.r_data;
     assign out_r_valid [0] = out.r_valid;
     assign out_r_opc   [0] = out.r_opc;
+    assign out_r_user  [0] = out.r_user;
 
     for(i=0; i<NB_OUT_CHAN; i++) begin : out_chan_binding
 
@@ -158,6 +169,7 @@ module hci_core_load_store_mixer
         out_be   [i] = in_be   [winner_d[i]*NB_OUT_CHAN+i];
         out_boffs[i] = in_boffs[winner_d[i]*NB_OUT_CHAN+i];
         out_lrdy [i] = in_lrdy [winner_d[i]*NB_OUT_CHAN+i];
+        out_user [i] = in_user [winner_d[i]*NB_OUT_CHAN+i];
       end
 
       always_ff @(posedge clk_i or negedge rst_ni)
@@ -196,16 +208,19 @@ module hci_core_load_store_mixer
           in_r_data  [j*NB_OUT_CHAN+i] = '0;
           in_r_valid [j*NB_OUT_CHAN+i] = 1'b0;
           in_r_opc   [j*NB_OUT_CHAN+i] = 1'b0;
+          in_r_user  [j*NB_OUT_CHAN+i] = '0;
         end
         if (out_r_valid[i]) begin
           in_r_data  [LOAD] = out_r_data[i];
           in_r_valid [LOAD] = out_r_valid[i];
           in_r_opc   [LOAD] = out_r_opc[i];
+          in_r_user  [LOAD] = out_r_user[i];
         end
         else begin
           in_r_data  [STORE] = out_r_data[i];
           in_r_valid [STORE] = out_r_valid[i];
           in_r_opc   [STORE] = out_r_opc[i];
+          in_r_user  [STORE] = out_r_user[i];
         end
       end
     end

--- a/rtl/core/hci_core_memmap_demux_interl.sv
+++ b/rtl/core/hci_core_memmap_demux_interl.sv
@@ -20,7 +20,8 @@ module hci_core_memmap_demux_interl #(
   parameter int unsigned NB_REGION = 2,
   parameter int unsigned AW  = hci_package::DEFAULT_AW, /// addr width
   parameter int unsigned AWC = hci_package::DEFAULT_AW, /// addr width core (useful part!)
-  parameter int unsigned DW  = hci_package::DEFAULT_DW
+  parameter int unsigned DW  = hci_package::DEFAULT_DW,
+  parameter int unsigned UW  = hci_package::DEFAULT_UW
 )
 (
   input  logic         clk_i,
@@ -43,6 +44,7 @@ module hci_core_memmap_demux_interl #(
     logic [NB_REGION-1:0]         master_r_valid_aux;
     logic [NB_REGION-1:0][DW-1:0] master_r_data_aux;
     logic [NB_REGION-1:0]         master_r_opc_aux;
+    logic [NB_REGION-1:0][UW-1:0] master_r_user_aux;
 
     logic [NB_REGION-1:0] destination_map;
     logic                 destination_valid;
@@ -116,16 +118,19 @@ module hci_core_memmap_demux_interl #(
           slave.r_valid = '0;
           slave.r_data  = '0;
           slave.r_opc   = '0;
+          slave.r_user  = '0;
         end
         RESPONSE: begin
           slave.r_valid = master_r_valid_aux [region_q];
           slave.r_data  = master_r_data_aux  [region_q];
           slave.r_opc   = master_r_opc_aux   [region_q];
+          slave.r_user  = master_r_user_aux  [region_q];
         end
         default: begin
           slave.r_valid = '0;
           slave.r_data  = '0;
           slave.r_opc   = '0;
+          slave.r_user  = '0;
         end
       endcase
       master_req_aux[region_d] = slave.req;
@@ -146,6 +151,7 @@ module hci_core_memmap_demux_interl #(
         assign master_r_valid_aux [ii] = master[ii].r_valid;
         assign master_r_data_aux  [ii] = master[ii].r_data;
         assign master_r_opc_aux   [ii] = master[ii].r_opc;
+        assign master_r_user_aux  [ii] = master[ii].r_user;
       end
     endgenerate
 

--- a/rtl/core/hci_core_memmap_demux_interl.sv
+++ b/rtl/core/hci_core_memmap_demux_interl.sv
@@ -18,8 +18,9 @@ import hwpe_stream_package::*;
 
 module hci_core_memmap_demux_interl #(
   parameter int unsigned NB_REGION = 2,
-  parameter int unsigned AW  = 32, /// addr width
-  parameter int unsigned AWC = 32  /// addr width core (useful part!)
+  parameter int unsigned AW  = hci_package::DEFAULT_AW, /// addr width
+  parameter int unsigned AWC = hci_package::DEFAULT_AW, /// addr width core (useful part!)
+  parameter int unsigned DW  = hci_package::DEFAULT_DW
 )
 (
   input  logic         clk_i,
@@ -38,10 +39,10 @@ module hci_core_memmap_demux_interl #(
     logic [$clog2(NB_REGION)-1:0] region_d, region_q;
     logic region_sample;
 
-    logic [NB_REGION-1:0]       master_req_aux, master_gnt_aux;
-    logic [NB_REGION-1:0]       master_r_valid_aux;
-    logic [NB_REGION-1:0][31:0] master_r_data_aux;
-    logic [NB_REGION-1:0]       master_r_opc_aux;
+    logic [NB_REGION-1:0]         master_req_aux, master_gnt_aux;
+    logic [NB_REGION-1:0]         master_r_valid_aux;
+    logic [NB_REGION-1:0][DW-1:0] master_r_data_aux;
+    logic [NB_REGION-1:0]         master_r_opc_aux;
 
     logic [NB_REGION-1:0] destination_map;
     logic                 destination_valid;

--- a/rtl/core/hci_core_memmap_filter.sv
+++ b/rtl/core/hci_core_memmap_filter.sv
@@ -119,6 +119,7 @@ module hci_core_memmap_filter #(
       interl_master.be    = slave.be;
       interl_master.boffs = slave.boffs;
       interl_master.lrdy  = slave.lrdy;
+      interl_master.user  = slave.user;
       // per_master request
       per_master.add   = slave.add;
       per_master.wen   = slave.wen;
@@ -126,32 +127,38 @@ module hci_core_memmap_filter #(
       per_master.be    = slave.be;
       per_master.boffs = slave.boffs;
       per_master.lrdy  = slave.lrdy;
+      per_master.user  = slave.user;
       // slave response
       case(state_q)
         IDLE: begin
           slave.r_valid = '0;
           slave.r_data  = '0;
           slave.r_opc   = '0;
+          slave.r_user  = '0;
         end
         ON_TCDM: begin
           slave.r_valid = interl_master.r_valid;
           slave.r_data  = interl_master.r_data;
           slave.r_opc   = interl_master.r_opc;
+          slave.r_user  = interl_master.r_user;
         end
         ON_PER: begin
           slave.r_valid = per_master.r_valid;
           slave.r_data  = per_master.r_data;
           slave.r_opc   = per_master.r_opc;
+          slave.r_user  = per_master.r_user;
         end
         ERROR: begin
           slave.r_valid = 1'b1;
           slave.r_data  = 32'hbadacce5; // May need modification for DW != 32
           slave.r_opc   = 1;
+          slave.r_user  = '0;
         end
         default: begin
           slave.r_valid = '0;
           slave.r_data  = '0;
           slave.r_opc   = '0;
+          slave.r_user  = '0;
         end
       endcase
     end

--- a/rtl/core/hci_core_memmap_filter.sv
+++ b/rtl/core/hci_core_memmap_filter.sv
@@ -19,7 +19,7 @@ import hwpe_stream_package::*;
 module hci_core_memmap_filter #(
   parameter int unsigned NB_REGION = 2,
   parameter int unsigned NB_INTERLEAVED_REGION = 1,
-  parameter int unsigned AW = 32 /// addr width
+  parameter int unsigned AW = hci_package::DEFAULT_AW /// addr width
 )
 (
   input  logic         clk_i,
@@ -145,7 +145,7 @@ module hci_core_memmap_filter #(
         end
         ERROR: begin
           slave.r_valid = 1'b1;
-          slave.r_data  = 32'hbadacce5;
+          slave.r_data  = 32'hbadacce5; // May need modification for DW != 32
           slave.r_opc   = 1;
         end
         default: begin

--- a/rtl/core/hci_core_mux_dynamic.sv
+++ b/rtl/core/hci_core_mux_dynamic.sv
@@ -55,7 +55,8 @@ module hci_core_mux_dynamic
   parameter int unsigned AW = hci_package::DEFAULT_AW,
   parameter int unsigned BW = hci_package::DEFAULT_BW,
   parameter int unsigned WW = hci_package::DEFAULT_WW,
-  parameter int unsigned OW = 1
+  parameter int unsigned OW = 1,
+  parameter int unsigned UW = hci_package::DEFAULT_UW
 )
 (
   input  logic         clk_i,
@@ -75,9 +76,11 @@ module hci_core_mux_dynamic
   logic [NB_IN_CHAN-1:0][DW/BW-1:0]          in_be;
   logic [NB_IN_CHAN-1:0][DW-1:0]             in_data;
   logic [NB_IN_CHAN-1:0][DW/WW-1:0][OW-1:0]  in_boffs;
+  logic [NB_IN_CHAN-1:0][UW-1:0]             in_user;
   logic [NB_IN_CHAN-1:0][DW-1:0]             in_r_data;
   logic [NB_IN_CHAN-1:0]                     in_r_valid;
   logic [NB_IN_CHAN-1:0]                     in_r_opc;
+  logic [NB_IN_CHAN-1:0][UW-1:0]             in_r_user;
 
   logic [NB_OUT_CHAN-1:0]                    out_req;
   logic [NB_OUT_CHAN-1:0]                    out_gnt;
@@ -87,9 +90,11 @@ module hci_core_mux_dynamic
   logic [NB_OUT_CHAN-1:0][DW/BW-1:0]         out_be;
   logic [NB_OUT_CHAN-1:0][DW-1:0]            out_data;
   logic [NB_OUT_CHAN-1:0][DW/WW-1:0][OW-1:0] out_boffs;
+  logic [NB_OUT_CHAN-1:0][UW-1:0]            out_user;
   logic [NB_OUT_CHAN-1:0][DW-1:0]            out_r_data;
   logic [NB_OUT_CHAN-1:0]                    out_r_valid;
   logic [NB_OUT_CHAN-1:0]                    out_r_opc;
+  logic [NB_OUT_CHAN-1:0][UW-1:0]            out_r_user;
 
   logic [$clog2(NB_IN_CHAN/NB_OUT_CHAN)-1:0]                                              rr_counter;
   logic [NB_OUT_CHAN-1:0][NB_IN_CHAN/NB_OUT_CHAN-1:0][$clog2(NB_IN_CHAN/NB_OUT_CHAN)-1:0] rr_priority;
@@ -122,10 +127,12 @@ module hci_core_mux_dynamic
       assign in_data  [j] = in[j].data;
       assign in_lrdy  [j] = in[j].lrdy;
       assign in_boffs [j] = in[j].boffs;
+      assign in_user  [j] = in[j].user;
       assign in[j].gnt     = in_gnt     [j];
       assign in[j].r_data  = in_r_data  [j];
       assign in[j].r_valid = in_r_valid [j];
       assign in[j].r_opc   = in_r_opc   [j];
+      assign in[j].r_user  = in_r_user  [j];
 
     end // in_chan_binding
 
@@ -138,10 +145,12 @@ module hci_core_mux_dynamic
       assign out[i].data  = out_data [i];
       assign out[i].lrdy  = out_lrdy [i];
       assign out[i].boffs = out_boffs [i];
+      assign out[i].user  = out_user [i];
       assign out_gnt     [i] = out[i].gnt;
       assign out_r_data  [i] = out[i].r_data;
       assign out_r_valid [i] = out[i].r_valid;
       assign out_r_opc   [i] = out[i].r_opc;
+      assign out_r_user  [i] = out[i].r_user;
 
       always_comb
       begin : rotating_priority_encoder_i
@@ -173,6 +182,7 @@ module hci_core_mux_dynamic
         out_be   [i] = in_be   [winner_d[i]*NB_OUT_CHAN+i];
         out_boffs[i] = in_boffs[winner_d[i]*NB_OUT_CHAN+i];
         out_lrdy [i] = in_lrdy [winner_d[i]*NB_OUT_CHAN+i];
+        out_user [i] = in_user [winner_d[i]*NB_OUT_CHAN+i];
       end
 
       always_ff @(posedge clk_i or negedge rst_ni)
@@ -201,11 +211,13 @@ module hci_core_mux_dynamic
           in_r_valid [j*NB_OUT_CHAN+i] = 1'b0;
           in_gnt     [j*NB_OUT_CHAN+i] = 1'b0;
           in_r_opc   [j*NB_OUT_CHAN+i] = 1'b0;
+          in_r_user  [j*NB_OUT_CHAN+i] = '0;
         end
         in_r_data  [winner_q[i]*NB_OUT_CHAN+i] = out_r_data[i];
         in_r_valid [winner_q[i]*NB_OUT_CHAN+i] = out_r_valid[i] & out_req_q[i];
         in_gnt     [winner_d[i]*NB_OUT_CHAN+i] = out_gnt[i];
         in_r_opc   [winner_d[i]*NB_OUT_CHAN+i] = out_r_opc[i];
+        in_r_user  [winner_d[i]*NB_OUT_CHAN+i] = out_r_user[i];
       end
     end
 

--- a/rtl/core/hci_core_mux_dynamic.sv
+++ b/rtl/core/hci_core_mux_dynamic.sv
@@ -51,10 +51,10 @@ module hci_core_mux_dynamic
 #(
   parameter int unsigned NB_IN_CHAN  = 2,
   parameter int unsigned NB_OUT_CHAN = 1,
-  parameter int unsigned DW = 32,
-  parameter int unsigned AW = 32,
-  parameter int unsigned BW = 8,
-  parameter int unsigned WW = 32,
+  parameter int unsigned DW = hci_package::DEFAULT_DW,
+  parameter int unsigned AW = hci_package::DEFAULT_AW,
+  parameter int unsigned BW = hci_package::DEFAULT_BW,
+  parameter int unsigned WW = hci_package::DEFAULT_WW,
   parameter int unsigned OW = 1
 )
 (

--- a/rtl/core/hci_core_mux_static.sv
+++ b/rtl/core/hci_core_mux_static.sv
@@ -26,7 +26,8 @@ module hci_core_mux_static
   parameter int unsigned AW = hci_package::DEFAULT_AW,
   parameter int unsigned BW = hci_package::DEFAULT_BW,
   parameter int unsigned WW = hci_package::DEFAULT_WW,
-  parameter int unsigned OW = AW
+  parameter int unsigned OW = AW,
+  parameter int unsigned UW = hci_package::DEFAULT_UW
 )
 (
   input  logic                       clk_i,
@@ -50,9 +51,11 @@ module hci_core_mux_static
     logic        [NB_CHAN-1:0][DW-1:0]            in_data;
     logic        [NB_CHAN-1:0][DW/BW-1:0]         in_be;
     logic signed [NB_CHAN-1:0][DW/WW-1:0][OW-1:0] in_boffs;
+    logic        [NB_CHAN-1:0][UW-1:0]            in_user;
     logic        [NB_CHAN-1:0][DW-1:0]            in_r_data;
     logic        [NB_CHAN-1:0]                    in_r_valid;
     logic        [NB_CHAN-1:0]                    in_r_opc;
+    logic        [NB_CHAN-1:0][UW-1:0]            in_r_user;
 
     for(genvar ii=0; ii<NB_CHAN; ii++) begin: tcdm_binding
 
@@ -64,14 +67,17 @@ module hci_core_mux_static
       assign in_data    [ii] = in[ii].data;
       assign in_be      [ii] = in[ii].be;
       assign in_boffs   [ii] = in[ii].boffs;
+      assign in_user    [ii] = in[ii].user;
       assign in_r_data  [ii] = in[ii].r_data;
       assign in_r_valid [ii] = in[ii].r_valid;
       assign in_r_opc   [ii] = in[ii].r_opc;
+      assign in_r_user  [ii] = in[ii].r_user;
 
       assign in[ii].gnt     = (sel_i == ii) ? out.gnt     : 1'b0;
       assign in[ii].r_valid = (sel_i == ii) ? out.r_valid : 1'b0;
       assign in[ii].r_data  = out.r_data;
       assign in[ii].r_opc   = out.r_opc;
+      assign in[ii].r_user  = out.r_user;
     end
 
     assign out.req   = in_req   [sel_i];
@@ -81,6 +87,7 @@ module hci_core_mux_static
     assign out.data  = in_data  [sel_i];
     assign out.lrdy  = in_lrdy  [sel_i];
     assign out.boffs = in_boffs [sel_i];
+    assign out.user  = in_user  [sel_i];
 
   endgenerate
 

--- a/rtl/core/hci_core_r_valid_filter.sv
+++ b/rtl/core/hci_core_r_valid_filter.sv
@@ -35,9 +35,11 @@ module hci_core_r_valid_filter
   assign tcdm_master.boffs = tcdm_slave.boffs;
   assign tcdm_master.req   = tcdm_slave.req;
   assign tcdm_master.lrdy  = tcdm_slave.lrdy;
+  assign tcdm_master.user  = tcdm_slave.user;
   assign tcdm_slave.gnt     = tcdm_master.gnt;
   assign tcdm_slave.r_data  = tcdm_master.r_data;
   assign tcdm_slave.r_opc   = tcdm_master.r_opc;
+  assign tcdm_slave.r_user  = tcdm_master.r_user;
   assign tcdm_slave.r_valid = enable_i ? tcdm_master.r_valid & wen_q : tcdm_master.r_valid;
 
   always_ff @(posedge clk_i or negedge rst_ni)

--- a/rtl/core/hci_core_sink.sv
+++ b/rtl/core/hci_core_sink.sv
@@ -19,9 +19,9 @@ import hci_package::*;
 module hci_core_sink
 #(
   // Stream interface params
-  parameter int unsigned DATA_WIDTH      = 32,
+  parameter int unsigned DATA_WIDTH      = hci_package::DEFAULT_DW,
   parameter int unsigned TCDM_FIFO_DEPTH = 0,
-  parameter int unsigned TRANS_CNT = 16
+  parameter int unsigned TRANS_CNT       = 16
 )
 (
   input logic clk_i,

--- a/rtl/core/hci_core_sink.sv
+++ b/rtl/core/hci_core_sink.sv
@@ -135,6 +135,9 @@ module hci_core_sink
   assign stream.ready    = ~stream.valid | (tcdm_prefifo.gnt & addr_fifo.valid);
   assign addr_fifo.ready =  stream.valid & stream.ready;
 
+  // unimplemented user bits = 0
+  assign tcdm_prefifo.user = '0;
+
   generate
 
     if(TCDM_FIFO_DEPTH != 0) begin: tcdm_fifos_gen

--- a/rtl/core/hci_core_source.sv
+++ b/rtl/core/hci_core_source.sv
@@ -19,7 +19,7 @@ import hci_package::*;
 module hci_core_source
 #(
   // Stream interface params
-  parameter int unsigned DATA_WIDTH = 32,
+  parameter int unsigned DATA_WIDTH = hci_package::DEFAULT_DW,
   parameter int unsigned LATCH_FIFO  = 0,
   parameter int unsigned TRANS_CNT = 16,
   parameter int unsigned ADDR_MIS_DEPTH = 8 // Beware: this must be >= the maximum latency between TCDM gnt and TCDM r_valid!!!

--- a/rtl/core/hci_core_source.sv
+++ b/rtl/core/hci_core_source.sv
@@ -20,6 +20,7 @@ module hci_core_source
 #(
   // Stream interface params
   parameter int unsigned DATA_WIDTH = hci_package::DEFAULT_DW,
+  // parameter int unsigned USER_WIDTH = hci_package::DEFAULT_UW, // User signals not implemented
   parameter int unsigned LATCH_FIFO  = 0,
   parameter int unsigned TRANS_CNT = 16,
   parameter int unsigned ADDR_MIS_DEPTH = 8 // Beware: this must be >= the maximum latency between TCDM gnt and TCDM r_valid!!!
@@ -121,6 +122,7 @@ module hci_core_source
   assign tcdm.be    = 4'h0;
   assign tcdm.data  = '0;
   assign tcdm.boffs = '0;
+  assign tcdm.user  = '0;
   assign stream.strb  = '1;
   assign stream.data  = stream_data_aligned;
   assign stream.valid = enable_i & (tcdm.r_valid | stream_valid_q); // is this strictly necessary to keep the HWPE-Stream protocol? or can be avoided with a FIFO q?

--- a/rtl/core/hci_core_split.sv
+++ b/rtl/core/hci_core_split.sv
@@ -16,7 +16,7 @@
 import hwpe_stream_package::*;
 
 module hci_core_split #(
-  parameter int unsigned DW = 64,
+  parameter int unsigned DW = 64, // DW_IN
   parameter int unsigned NB_OUT_CHAN = 2
 ) (
   input logic clk_i,
@@ -33,6 +33,12 @@ module hci_core_split #(
   logic [NB_OUT_CHAN-1:0]             tcdm_master_r_valid_d, tcdm_master_r_valid_q;
   logic [NB_OUT_CHAN-1:0]             tcdm_slave_req_masked_d, tcdm_slave_req_masked_q;
   logic [NB_OUT_CHAN-1:0][DW_OUT-1:0] tcdm_master_r_data_d, tcdm_master_r_data_q;
+
+  // User bits not implemented in split
+  for (genvar i=0; i<NB_OUT_CHAN; i++) begin
+    assign tcdm_master[i].user = '0;
+  end
+  assign tcdm_slave.r_user = '0;
 
   for(genvar ii=0; ii<NB_OUT_CHAN; ii++) begin : gnt_r_valid_gen
     assign tcdm_master_gnt     [ii] = tcdm_master[ii].gnt;

--- a/rtl/hci_interconnect.sv
+++ b/rtl/hci_interconnect.sv
@@ -19,34 +19,35 @@
 import hci_package::*;
 
 module hci_interconnect #(
-  parameter int unsigned N_HWPE  = 4,
-  parameter int unsigned N_CORE  = 8,
-  parameter int unsigned N_DMA   = 4,
-  parameter int unsigned N_EXT   = 4,
-  parameter int unsigned N_MEM   = 16,
-  parameter int unsigned AWC     = 32,
-  parameter int unsigned AWM     = 32,
-  parameter int unsigned DW_LIC  = 32,
-  parameter int unsigned DW_SIC  = 128,
-  parameter int unsigned TS_BIT  = 21,
-  parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT,
-  parameter int unsigned EXPFIFO = 0,
-  parameter int unsigned DWH = hci_package::DEFAULT_DW,
-  parameter int unsigned AWH = hci_package::DEFAULT_AW,
-  parameter int unsigned BWH = hci_package::DEFAULT_BW,
-  parameter int unsigned WWH = hci_package::DEFAULT_WW,
-  parameter int unsigned OWH = AWH,
-  parameter int unsigned SEL_LIC = 0
+  parameter int unsigned N_HWPE  = 4                        , // Number of HWPEs attached to the port
+  parameter int unsigned N_CORE  = 8                        , // Number of Core ports
+  parameter int unsigned N_DMA   = 4                        , // Number of DMA ports
+  parameter int unsigned N_EXT   = 4                        , // Number of External ports
+  parameter int unsigned N_MEM   = 16                       , // Number of Memory banks
+  parameter int unsigned AWC     = hci_package::DEFAULT_AW  , // Address Width Core   (slave ports)
+  parameter int unsigned AWM     = hci_package::DEFAULT_AW  , // Address width memory (master ports)
+  parameter int unsigned DW_LIC  = hci_package::DEFAULT_DW  , // Data Width for Log Interconnect
+  parameter int unsigned BW_LIC  = hci_package::DEFAULT_BW  , // Byte Width for Log Interconnect
+  parameter int unsigned DW_SIC  = 128                      , // UNUSED!!!
+  parameter int unsigned TS_BIT  = 21                       , // TEST_SET_BIT (for Log Interconnect)
+  parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
+  parameter int unsigned EXPFIFO = 0                        , // FIFO Depth for HWPE Interconnect
+  parameter int unsigned DWH     = hci_package::DEFAULT_DW  , // Data Width for HWPE Interconnect
+  parameter int unsigned AWH     = hci_package::DEFAULT_AW  , // Address Width for HWPE Interconnect
+  parameter int unsigned BWH     = hci_package::DEFAULT_BW  , // Byte Width for HWPE Interconnect
+  parameter int unsigned WWH     = hci_package::DEFAULT_WW  , // Word Width for HWPE Interconnect
+  parameter int unsigned OWH     = AWH                      , // Offset Width for HWPE Interconnect
+  parameter int unsigned SEL_LIC = 0                          // Log interconnect type selector
 ) (
-  input  logic                   clk_i,
-  input  logic                   rst_ni,
-  input  logic                   clear_i,
-  input  hci_interconnect_ctrl_t ctrl_i,
-  hci_core_intf.slave            cores   [N_CORE-1:0],
-  hci_core_intf.slave            dma     [N_DMA-1:0],
-  hci_core_intf.slave            ext     [N_EXT-1:0],
-  hci_mem_intf.master            mems    [N_MEM-1:0],
-  hci_core_intf.slave            hwpe
+  input logic                   clk_i               ,
+  input logic                   rst_ni              ,
+  input logic                   clear_i             ,
+  input hci_interconnect_ctrl_t ctrl_i              ,
+  hci_core_intf.slave           cores   [N_CORE-1:0],
+  hci_core_intf.slave           dma     [N_DMA-1:0] ,
+  hci_core_intf.slave           ext     [N_EXT-1:0] ,
+  hci_mem_intf.master           mems    [N_MEM-1:0] ,
+  hci_core_intf.slave           hwpe
 );
 
   hci_core_intf all_except_hwpe [N_CORE+N_DMA+N_EXT-1:0] (
@@ -75,6 +76,7 @@ module hci_interconnect #(
         .AWC    ( AWC                 ),
         .AWM    ( AWM-2               ),
         .DW     ( DW_LIC              ),
+        .BW     ( BW_LIC              ),
         .TS_BIT ( TS_BIT              )
       ) i_log_interconnect (
         .clk_i  ( clk_i               ),
@@ -92,7 +94,8 @@ module hci_interconnect #(
         .IW     ( IW                  ),
         .AWC    ( AWC                 ),
         .AWM    ( AWM                 ),
-        .DW     ( DW_LIC              )
+        .DW     ( DW_LIC              ),
+        .BW     ( BW_LIC              )
       ) i_log_interconnect (
         .clk_i  ( clk_i               ),
         .rst_ni ( rst_ni              ),
@@ -110,6 +113,7 @@ module hci_interconnect #(
         .AWC    ( AWC                 ),
         .AWM    ( AWM-2               ),
         .DW     ( DW_LIC              ),
+        .BW     ( BW_LIC              ),
         .TS_BIT ( TS_BIT              )
       ) i_log_interconnect (
         .clk_i  ( clk_i               ),

--- a/rtl/hci_interconnect.sv
+++ b/rtl/hci_interconnect.sv
@@ -28,6 +28,7 @@ module hci_interconnect #(
   parameter int unsigned AWM     = hci_package::DEFAULT_AW  , // Address width memory (master ports)
   parameter int unsigned DW_LIC  = hci_package::DEFAULT_DW  , // Data Width for Log Interconnect
   parameter int unsigned BW_LIC  = hci_package::DEFAULT_BW  , // Byte Width for Log Interconnect
+  parameter int unsigned UW_LIC  = hci_package::DEFAULT_UW  , // User Width for Log Interconnect
   parameter int unsigned DW_SIC  = 128                      , // UNUSED!!!
   parameter int unsigned TS_BIT  = 21                       , // TEST_SET_BIT (for Log Interconnect)
   parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
@@ -37,6 +38,7 @@ module hci_interconnect #(
   parameter int unsigned BWH     = hci_package::DEFAULT_BW  , // Byte Width for HWPE Interconnect
   parameter int unsigned WWH     = hci_package::DEFAULT_WW  , // Word Width for HWPE Interconnect
   parameter int unsigned OWH     = AWH                      , // Offset Width for HWPE Interconnect
+  parameter int unsigned UWH     = hci_package::DEFAULT_UW  , // User Width for HWPE Interconnect
   parameter int unsigned SEL_LIC = 0                          // Log interconnect type selector
 ) (
   input logic                   clk_i               ,
@@ -50,18 +52,22 @@ module hci_interconnect #(
   hci_core_intf.slave           hwpe
 );
 
-  hci_core_intf all_except_hwpe [N_CORE+N_DMA+N_EXT-1:0] (
+  hci_core_intf #(
+    .UW ( UW_LIC )
+  ) all_except_hwpe [N_CORE+N_DMA+N_EXT-1:0] (
     .clk ( clk_i )
   );
 
   hci_mem_intf #(
-    .IW ( IW )
+    .IW ( IW     ),
+    .UW ( UW_LIC )
   ) all_except_hwpe_mem [N_MEM-1:0] (
     .clk ( clk_i )
   );
 
   hci_mem_intf #(
-    .IW ( IW )
+    .IW ( IW     ),
+    .UW ( UW_LIC )
   ) hwpe_mem [N_MEM-1:0] (
     .clk ( clk_i )
   );
@@ -77,6 +83,7 @@ module hci_interconnect #(
         .AWM    ( AWM-2               ),
         .DW     ( DW_LIC              ),
         .BW     ( BW_LIC              ),
+        .UW     ( UW_LIC              ),
         .TS_BIT ( TS_BIT              )
       ) i_log_interconnect (
         .clk_i  ( clk_i               ),
@@ -95,7 +102,8 @@ module hci_interconnect #(
         .AWC    ( AWC                 ),
         .AWM    ( AWM                 ),
         .DW     ( DW_LIC              ),
-        .BW     ( BW_LIC              )
+        .BW     ( BW_LIC              ),
+        .UW     ( UW_LIC              )
       ) i_log_interconnect (
         .clk_i  ( clk_i               ),
         .rst_ni ( rst_ni              ),
@@ -114,6 +122,7 @@ module hci_interconnect #(
         .AWM    ( AWM-2               ),
         .DW     ( DW_LIC              ),
         .BW     ( BW_LIC              ),
+        .UW     ( UW_LIC              ),
         .TS_BIT ( TS_BIT              )
       ) i_log_interconnect (
         .clk_i  ( clk_i               ),
@@ -136,7 +145,8 @@ module hci_interconnect #(
         .AWH         ( AWH     ),
         .BWH         ( BWH     ),
         .WWH         ( WWH     ),
-        .OWH         ( OWH     )
+        .OWH         ( OWH     ),
+        .UWH         ( UWH     )
       ) i_hwpe_interconnect (
         .clk_i   ( clk_i    ),
         .rst_ni  ( rst_ni   ),

--- a/rtl/interco/hci_hwpe_interconnect.sv
+++ b/rtl/interco/hci_hwpe_interconnect.sv
@@ -36,6 +36,7 @@ module hci_hwpe_interconnect
   parameter int unsigned BWH = hci_package::DEFAULT_BW,
   parameter int unsigned WWH = hci_package::DEFAULT_WW,
   parameter int unsigned OWH = AWH,
+  parameter int unsigned UWH = hci_package::DEFAULT_UW, // User Width not yet implemented
   parameter int unsigned AWM = 12
 )
 (
@@ -73,7 +74,8 @@ module hci_hwpe_interconnect
     .AW ( AWH ),
     .BW ( BWH ),
     .WW ( WWH ),
-    .OW ( OWH ) 
+    .OW ( OWH ),
+    .UW ( UWH )
   ) postfifo (
     .clk ( clk_i )
   );
@@ -106,7 +108,8 @@ module hci_hwpe_interconnect
         .BW         ( AWH        ),
         .AW         ( BWH        ),
         .WW         ( WWH        ),
-        .OW         ( OWH        )
+        .OW         ( OWH        ),
+        .UW         ( UWH        )
       ) i_fifo (
         .clk_i       ( clk_i         ),
         .rst_ni      ( rst_ni        ),
@@ -116,6 +119,9 @@ module hci_hwpe_interconnect
         .tcdm_master ( postfifo      )
       );
     end // fifo_gen
+
+    // unimplemented user bits = 0
+    assign postfifo.r_user = '0;
     
     assign bank_offset_s = postfifo.add[LSB_COMMON_ADDR-1:2];
     assign reorder_offset_s = NB_OUT_CHAN - bank_offset_s;
@@ -163,6 +169,9 @@ module hci_hwpe_interconnect
       assign virt_out[ii].gnt     = out[ii].gnt;
       assign virt_out[ii].r_valid = out_r_valid[ii];
       assign virt_out[ii].r_data  = out[ii].r_data;
+
+      // unimplemented user bits = 0
+      assign out[ii].user = '0;
 
       // generate out_r_valid
       always_ff @(posedge clk_i or negedge rst_ni)

--- a/rtl/interco/hci_hwpe_interconnect.sv
+++ b/rtl/interco/hci_hwpe_interconnect.sv
@@ -94,27 +94,27 @@ module hci_hwpe_interconnect
 
     // FIFOs for HWPE ports
     if(FIFO_DEPTH == 0) begin: no_fifo_gen
-    hci_core_assign i_no_fifo (
-      .tcdm_slave  ( in            ),
-      .tcdm_master ( postfifo      )
-    );
+      hci_core_assign i_no_fifo (
+        .tcdm_slave  ( in            ),
+        .tcdm_master ( postfifo      )
+      );
     end // no_fifo_gen
     else begin: fifo_gen
-    hci_core_fifo #(
-      .FIFO_DEPTH ( FIFO_DEPTH ),
-      .DW         ( DWH        ),
-      .BW         ( AWH        ),
-      .AW         ( BWH        ),
-      .WW         ( WWH        ),
-      .OW         ( OWH        )
-    ) i_fifo (
-      .clk_i       ( clk_i         ),
-      .rst_ni      ( rst_ni        ),
-      .clear_i     ( clear_i       ),
-      .flags_o     (               ),
-      .tcdm_slave  ( in            ),
-      .tcdm_master ( postfifo      )
-    );
+      hci_core_fifo #(
+        .FIFO_DEPTH ( FIFO_DEPTH ),
+        .DW         ( DWH        ),
+        .BW         ( AWH        ),
+        .AW         ( BWH        ),
+        .WW         ( WWH        ),
+        .OW         ( OWH        )
+      ) i_fifo (
+        .clk_i       ( clk_i         ),
+        .rst_ni      ( rst_ni        ),
+        .clear_i     ( clear_i       ),
+        .flags_o     (               ),
+        .tcdm_slave  ( in            ),
+        .tcdm_master ( postfifo      )
+      );
     end // fifo_gen
     
     assign bank_offset_s = postfifo.add[LSB_COMMON_ADDR-1:2];

--- a/rtl/interco/hci_log_interconnect.sv
+++ b/rtl/interco/hci_log_interconnect.sv
@@ -21,9 +21,10 @@ module hci_log_interconnect #(
   parameter int unsigned N_CH0  = 16,
   parameter int unsigned N_CH1  = 4,
   parameter int unsigned N_MEM  = 32,
-  parameter int unsigned AWC    = 32,
-  parameter int unsigned AWM    = 32,
-  parameter int unsigned DW     = 32,
+  parameter int unsigned AWC    = hci_package::DEFAULT_AW,
+  parameter int unsigned AWM    = hci_package::DEFAULT_AW,
+  parameter int unsigned DW     = hci_package::DEFAULT_DW,
+  parameter int unsigned BW     = hci_package::DEFAULT_BW,
   parameter int unsigned TS_BIT = 21,
   parameter int unsigned IW     = N_CH0+N_CH1
 ) (
@@ -33,8 +34,6 @@ module hci_log_interconnect #(
   hci_core_intf.slave            cores [N_CH0+N_CH1-1:0],
   hci_mem_intf.master            mems  [N_MEM-1:0]
 );
-
-  localparam BW = 8;
 
   // master side
   logic [N_CH0+N_CH1-1:0]             cores_req;

--- a/rtl/interco/hci_log_interconnect.sv
+++ b/rtl/interco/hci_log_interconnect.sv
@@ -26,7 +26,8 @@ module hci_log_interconnect #(
   parameter int unsigned DW     = hci_package::DEFAULT_DW,
   parameter int unsigned BW     = hci_package::DEFAULT_BW,
   parameter int unsigned TS_BIT = 21,
-  parameter int unsigned IW     = N_CH0+N_CH1
+  parameter int unsigned IW     = N_CH0+N_CH1,
+  parameter int unsigned UW     = hci_package::DEFAULT_UW
 ) (
   input  logic                   clk_i,
   input  logic                   rst_ni,
@@ -39,20 +40,20 @@ module hci_log_interconnect #(
   logic [N_CH0+N_CH1-1:0]             cores_req;
   logic [N_CH0+N_CH1-1:0] [AWC-1:0]   cores_add;
   logic [N_CH0+N_CH1-1:0]             cores_wen;
-  logic [N_CH0+N_CH1-1:0] [DW-1:0]    cores_wdata;
+  logic [N_CH0+N_CH1-1:0] [UW+DW-1:0] cores_wdata;
   logic [N_CH0+N_CH1-1:0] [DW/BW-1:0] cores_be;
   logic [N_CH0+N_CH1-1:0]             cores_gnt;
   logic [N_CH0+N_CH1-1:0]             cores_r_valid;
-  logic [N_CH0+N_CH1-1:0] [DW-1:0]    cores_r_rdata;
+  logic [N_CH0+N_CH1-1:0] [UW+DW-1:0] cores_r_rdata;
   // slave side
   logic [N_MEM-1:0]             mems_req;
   logic [N_MEM-1:0] [AWM-1:0]   mems_add;
   logic [N_MEM-1:0]             mems_wen;
-  logic [N_MEM-1:0] [DW-1:0]    mems_wdata;
+  logic [N_MEM-1:0] [UW+DW-1:0] mems_wdata;
   logic [N_MEM-1:0] [DW/BW-1:0] mems_be;
   logic [N_MEM-1:0] [IW-1:0]    mems_ID;
   logic [N_MEM-1:0]             mems_gnt;
-  logic [N_MEM-1:0] [DW-1:0]    mems_r_rdata;
+  logic [N_MEM-1:0] [UW+DW-1:0] mems_r_rdata;
   logic [N_MEM-1:0]             mems_r_valid;
   logic [N_MEM-1:0] [IW-1:0]    mems_r_ID;
   logic [N_MEM-1:0]             mems_ts_set_d;
@@ -64,11 +65,17 @@ module hci_log_interconnect #(
       assign cores_req   [i] = cores[i].req;
       assign cores_add   [i] = cores[i].add;
       assign cores_wen   [i] = cores[i].wen;
-      assign cores_wdata [i] = cores[i].data;
       assign cores_be    [i] = cores[i].be;
+      if (UW > 0) begin
+        assign cores_wdata [i] = {cores[i].user, cores[i].data};
+        assign {cores[i].r_user, cores[i].r_data}  = cores_r_rdata [i];
+      end else begin
+        assign cores_wdata [i] = cores[i].data;
+        assign cores[i].r_data = cores_r_rdata [i];
+        assign cores[i].r_user = '0;
+      end
       assign cores[i].gnt     = cores_gnt     [i];
       assign cores[i].r_valid = cores_r_valid [i];
-      assign cores[i].r_data  = cores_r_rdata [i];
       assign cores[i].r_opc   = '0;
     end // cores_unrolling
     for(genvar i=0; i<N_MEM; i++) begin : mems_unrolling
@@ -77,11 +84,17 @@ module hci_log_interconnect #(
       assign mems[i].add [1:0]         = '0;
       assign mems[i].add [AWC-1:AWC-2] = '0;
       assign mems[i].wen               = mems_wen   [i];
-      assign mems[i].data              = mems_wdata [i];
       assign mems[i].be                = mems_be    [i];
       assign mems[i].id                = mems_ID    [i];
-      assign mems_gnt     [i] = mems[i].gnt;
-      assign mems_r_rdata [i] = mems[i].r_data;
+      if (UW > 0) begin
+        assign {mems[i].user, mems[i].data} = mems_wdata [i];
+        assign mems_r_rdata [i] = {mems[i].r_user, mems[i].r_data};
+      end else begin
+        assign mems[i].data     = mems_wdata [i];
+        assign mems[i].user     = '0;
+        assign mems_r_rdata [i] = mems[i].r_data;
+      end
+      assign mems_gnt       [i] = mems[i].gnt;
 
       always_ff @(posedge clk_i or negedge rst_ni)
       begin : resp_test_set
@@ -108,7 +121,7 @@ module hci_log_interconnect #(
     .N_SLAVE        ( N_MEM  ),
     .ID_WIDTH       ( IW     ),
     .ADDR_WIDTH     ( AWC    ),
-    .DATA_WIDTH     ( DW     ),
+    .DATA_WIDTH     ( UW+DW  ),
     .BE_WIDTH       ( DW/BW  ),
     .ADDR_MEM_WIDTH ( AWM    ),
     .TEST_SET_BIT   ( TS_BIT )

--- a/rtl/interco/hci_log_interconnect_l2.sv
+++ b/rtl/interco/hci_log_interconnect_l2.sv
@@ -25,7 +25,8 @@ module hci_log_interconnect_l2 #(
   parameter int unsigned AWM    = hci_package::DEFAULT_AW,
   parameter int unsigned DW     = hci_package::DEFAULT_DW,
   parameter int unsigned BW     = hci_package::DEFAULT_BW,
-  parameter int unsigned IW     = N_CH0+N_CH1
+  parameter int unsigned IW     = N_CH0+N_CH1,
+  parameter int unsigned UW     = hci_package::DEFAULT_UW
 ) (
   input  logic                   clk_i,
   input  logic                   rst_ni,
@@ -38,20 +39,20 @@ module hci_log_interconnect_l2 #(
   logic [N_CH0+N_CH1-1:0]             cores_req;
   logic [N_CH0+N_CH1-1:0] [AWC-3:0]   cores_add;
   logic [N_CH0+N_CH1-1:0]             cores_wen;
-  logic [N_CH0+N_CH1-1:0] [DW-1:0]    cores_wdata;
+  logic [N_CH0+N_CH1-1:0] [UW+DW-1:0] cores_wdata;
   logic [N_CH0+N_CH1-1:0] [DW/BW-1:0] cores_be;
   logic [N_CH0+N_CH1-1:0]             cores_gnt;
   logic [N_CH0+N_CH1-1:0]             cores_r_valid;
-  logic [N_CH0+N_CH1-1:0] [DW-1:0]    cores_r_rdata;
+  logic [N_CH0+N_CH1-1:0] [UW+DW-1:0] cores_r_rdata;
   // slave side
   logic [N_MEM-1:0]             mems_req;
   logic [N_MEM-1:0] [AWM-3:0]   mems_add;
   logic [N_MEM-1:0]             mems_wen;
-  logic [N_MEM-1:0] [DW-1:0]    mems_wdata;
+  logic [N_MEM-1:0] [UW+DW-1:0] mems_wdata;
   logic [N_MEM-1:0] [DW/BW-1:0] mems_be;
   logic [N_MEM-1:0] [IW-1:0]    mems_ID;
   logic [N_MEM-1:0]             mems_gnt;
-  logic [N_MEM-1:0] [DW-1:0]    mems_r_rdata;
+  logic [N_MEM-1:0] [UW+DW-1:0] mems_r_rdata;
   logic [N_MEM-1:0]             mems_r_valid;
   logic [N_MEM-1:0] [IW-1:0]    mems_r_ID;
 
@@ -61,11 +62,17 @@ module hci_log_interconnect_l2 #(
       assign cores_req   [i] = cores[i].req;
       assign cores_add   [i] = cores[i].add [AWC-1:2];
       assign cores_wen   [i] = cores[i].wen;
-      assign cores_wdata [i] = cores[i].data;
       assign cores_be    [i] = cores[i].be;
+      if (UW > 0) begin
+        assign cores_wdata [i] = {cores[i].user, cores[i].data};
+        assign {cores[i].r_user, cores[i].r_data} = cores_r_rdata [i];
+      end else begin
+        assign cores_wdata [i] = cores[i].data;
+        assign cores[i].r_data = cores_r_rdata [i];
+        assign cores[i].r_user = '0;
+      end
       assign cores[i].gnt     = cores_gnt     [i];
       assign cores[i].r_valid = cores_r_valid [i];
-      assign cores[i].r_data  = cores_r_rdata [i];
       assign cores[i].r_opc   = '0;
     end // cores_unrolling
     for(genvar i=0; i<N_MEM; i++) begin : mems_unrolling
@@ -73,11 +80,17 @@ module hci_log_interconnect_l2 #(
       assign mems[i].add [AWC-3:2] = mems_add [i];
       assign mems[i].add [1:0]     = '0;
       assign mems[i].wen  = mems_wen    [i];
-      assign mems[i].data = mems_wdata  [i];
       assign mems[i].be   = mems_be     [i];
       assign mems[i].id   = mems_ID     [i];
+      if (UW > 0) begin
+        assign {mems[i].user, mems[i].data} = mems_wdata [i];
+        assign mems_r_rdata [i] = {mems[i].r_user, mems[i].r_data};
+      end else begin
+        assign mems[i].data     = mems_wdata [i];
+        assign mems[i].user     = '0;
+        assign mems_r_rdata [i] = mems[i].r_data;
+      end
       assign mems_gnt     [i] = mems[i].gnt;
-      assign mems_r_rdata [i] = mems[i].r_data;
       assign mems_r_ID    [i] = mems[i].r_id;
 
       always_ff @(posedge clk_i or negedge rst_ni)
@@ -100,7 +113,7 @@ module hci_log_interconnect_l2 #(
     .N_SLAVE        ( N_MEM  ),
     .ID_WIDTH       ( IW     ),
     .ADDR_IN_WIDTH  ( AWC-2  ),
-    .DATA_WIDTH     ( DW     ),
+    .DATA_WIDTH     ( UW+DW  ),
     .BE_WIDTH       ( DW/BW  ),
     .ADDR_MEM_WIDTH ( AWM-2  )
   ) i_xbar_tcdm (

--- a/rtl/interco/hci_log_interconnect_l2.sv
+++ b/rtl/interco/hci_log_interconnect_l2.sv
@@ -21,10 +21,10 @@ module hci_log_interconnect_l2 #(
   parameter int unsigned N_CH0  = 16,
   parameter int unsigned N_CH1  = 4,
   parameter int unsigned N_MEM  = 32,
-  parameter int unsigned AWC    = 32,
-  parameter int unsigned AWM    = 32,
-  parameter int unsigned DW     = 32,
-  parameter int unsigned TS_BIT = 21,
+  parameter int unsigned AWC    = hci_package::DEFAULT_AW,
+  parameter int unsigned AWM    = hci_package::DEFAULT_AW,
+  parameter int unsigned DW     = hci_package::DEFAULT_DW,
+  parameter int unsigned BW     = hci_package::DEFAULT_BW,
   parameter int unsigned IW     = N_CH0+N_CH1
 ) (
   input  logic                   clk_i,
@@ -33,8 +33,6 @@ module hci_log_interconnect_l2 #(
   hci_core_intf.slave            cores [N_CH0+N_CH1-1:0],
   hci_mem_intf.master            mems  [N_MEM-1:0]
 );
-
-  localparam BW = 8;
 
   // master side
   logic [N_CH0+N_CH1-1:0]             cores_req;

--- a/rtl/interco/hci_new_log_interconnect.sv
+++ b/rtl/interco/hci_new_log_interconnect.sv
@@ -21,9 +21,10 @@ module hci_new_log_interconnect #(
   parameter int unsigned N_CH0  = 16,
   parameter int unsigned N_CH1  = 4,
   parameter int unsigned N_MEM  = 32,
-  parameter int unsigned AWC    = 32,
-  parameter int unsigned AWM    = 32,
-  parameter int unsigned DW     = 32,
+  parameter int unsigned AWC    = hci_package::DEFAULT_AW,
+  parameter int unsigned AWM    = hci_package::DEFAULT_AW,
+  parameter int unsigned DW     = hci_package::DEFAULT_DW,
+  parameter int unsigned BW     = hci_package::DEFAULT_BW,
   parameter int unsigned TS_BIT = 21,
   parameter int unsigned IW     = N_CH0+N_CH1
 ) (
@@ -33,8 +34,6 @@ module hci_new_log_interconnect #(
   hci_core_intf.slave            cores [N_CH0+N_CH1-1:0],
   hci_mem_intf.master            mems  [N_MEM-1:0]
 );
-
-  localparam BW = 8;
 
   // master side
   logic [N_CH0+N_CH1-1:0]             cores_req;

--- a/rtl/interco/hci_new_log_interconnect.sv
+++ b/rtl/interco/hci_new_log_interconnect.sv
@@ -26,33 +26,34 @@ module hci_new_log_interconnect #(
   parameter int unsigned DW     = hci_package::DEFAULT_DW,
   parameter int unsigned BW     = hci_package::DEFAULT_BW,
   parameter int unsigned TS_BIT = 21,
-  parameter int unsigned IW     = N_CH0+N_CH1
+  parameter int unsigned IW     = N_CH0+N_CH1,
+  parameter int unsigned UW     = hci_package::DEFAULT_UW
 ) (
-  input  logic                   clk_i,
-  input  logic                   rst_ni,
-  input  hci_interconnect_ctrl_t ctrl_i,
-  hci_core_intf.slave            cores [N_CH0+N_CH1-1:0],
-  hci_mem_intf.master            mems  [N_MEM-1:0]
+  input logic                   clk_i,
+  input logic                   rst_ni,
+  input hci_interconnect_ctrl_t ctrl_i,
+  hci_core_intf.slave           cores [N_CH0+N_CH1-1:0],
+  hci_mem_intf.master           mems  [N_MEM-1:0]
 );
 
   // master side
   logic [N_CH0+N_CH1-1:0]             cores_req;
   logic [N_CH0+N_CH1-1:0] [AWC-1:0]   cores_add;
   logic [N_CH0+N_CH1-1:0]             cores_wen;
-  logic [N_CH0+N_CH1-1:0] [DW-1:0]    cores_wdata;
+  logic [N_CH0+N_CH1-1:0] [UW+DW-1:0] cores_wdata;
   logic [N_CH0+N_CH1-1:0] [DW/BW-1:0] cores_be;
   logic [N_CH0+N_CH1-1:0]             cores_gnt;
   logic [N_CH0+N_CH1-1:0]             cores_r_valid;
-  logic [N_CH0+N_CH1-1:0] [DW-1:0]    cores_r_rdata;
+  logic [N_CH0+N_CH1-1:0] [UW+DW-1:0] cores_r_rdata;
   // slave side
   logic [N_MEM-1:0]             mems_req;
   logic [N_MEM-1:0] [AWM-1:0]   mems_add;
   logic [N_MEM-1:0]             mems_wen;
-  logic [N_MEM-1:0] [DW-1:0]    mems_wdata;
+  logic [N_MEM-1:0] [UW+DW-1:0] mems_wdata;
   logic [N_MEM-1:0] [DW/BW-1:0] mems_be;
   logic [N_MEM-1:0] [IW-1:0]    mems_ID;
   logic [N_MEM-1:0]             mems_gnt;
-  logic [N_MEM-1:0] [DW-1:0]    mems_r_rdata;
+  logic [N_MEM-1:0] [UW+DW-1:0] mems_r_rdata;
   logic [N_MEM-1:0]             mems_r_valid;
   logic [N_MEM-1:0] [IW-1:0]    mems_r_ID;
   logic [N_MEM-1:0]             mems_ts_set_d;
@@ -61,15 +62,21 @@ module hci_new_log_interconnect #(
   // interface unrolling
   generate
     for(genvar i=0; i<N_CH0+N_CH1; i++) begin : cores_unrolling
-      assign cores_req   [i] = cores[i].req;
-      assign cores_add   [i] = cores[i].add;
-      assign cores_wen   [i] = cores[i].wen;
-      assign cores_wdata [i] = cores[i].data;
-      assign cores_be    [i] = cores[i].be;
-      assign cores[i].gnt     = cores_gnt     [i];
-      assign cores[i].r_valid = cores_r_valid [i];
-      assign cores[i].r_data  = cores_r_rdata [i];
-      assign cores[i].r_opc   = '0;
+      assign cores_req     [i] = cores[i].req;
+      assign cores_add     [i] = cores[i].add;
+      assign cores_wen     [i] = cores[i].wen;
+      assign cores_be      [i] = cores[i].be;
+      if (UW > 0) begin
+        assign cores_wdata [i] = {cores[i].user, cores[i].data};
+        assign {cores[i].r_user, cores[i].r_data} = cores_r_rdata [i];
+      end else begin
+        assign cores_wdata [i] = cores[i].data;
+        assign cores[i].r_data = cores_r_rdata [i];
+        assign cores[i].r_user = '0;
+      end
+      assign cores[i].gnt      = cores_gnt     [i];
+      assign cores[i].r_valid  = cores_r_valid [i];
+      assign cores[i].r_opc    = '0;
     end // cores_unrolling
     for(genvar i=0; i<N_MEM; i++) begin : mems_unrolling
       assign mems[i].req               = mems_req   [i];
@@ -77,11 +84,17 @@ module hci_new_log_interconnect #(
       assign mems[i].add [1:0]         = '0;
       assign mems[i].add [AWC-1:AWC-2] = '0;
       assign mems[i].wen               = mems_wen   [i];
-      assign mems[i].data              = mems_wdata [i];
       assign mems[i].be                = mems_be    [i];
       assign mems[i].id                = mems_ID    [i];
-      assign mems_gnt     [i] = mems[i].gnt;
-      assign mems_r_rdata [i] = mems[i].r_data;
+      if (UW > 0) begin
+        assign {mems[i].user, mems[i].data} = mems_wdata [i];
+        assign mems_r_rdata [i] = {mems[i].r_user, mems[i].r_data};
+      end else begin
+        assign mems[i].data     = mems_wdata [i];
+        assign mems[i].user     = '0;
+        assign mems_r_rdata [i] = mems[i].r_data;
+      end
+      assign mems_gnt       [i] = mems[i].gnt;
 
       always_ff @(posedge clk_i or negedge rst_ni)
       begin : resp_test_set
@@ -92,9 +105,9 @@ module hci_new_log_interconnect #(
         end
         else begin
           mems_ts_set_q[i] <= mems_ts_set_d[i];
-          mems_r_valid[i] <= ( mems_req[i] & mems_gnt[i] & ~mems_ts_set_d[i]  & ~mems_ts_set_q[i] ) | (mems_req[i] & mems_gnt[i] & ~mems_ts_set_d[i]  & mems_ts_set_q[i] );
+          mems_r_valid[i]  <= ( mems_req[i] & mems_gnt[i] & ~mems_ts_set_d[i]  & ~mems_ts_set_q[i] ) | (mems_req[i] & mems_gnt[i] & ~mems_ts_set_d[i]  & mems_ts_set_q[i] );
           if(mems_req[i])
-            mems_r_ID[i] <= mems_ID[i];
+            mems_r_ID[i]   <= mems_ID[i];
         end
       end
 
@@ -108,7 +121,7 @@ module hci_new_log_interconnect #(
     .N_SLAVE        ( N_MEM  ),
     .ID_WIDTH       ( IW     ),
     .ADDR_WIDTH     ( AWC    ),
-    .DATA_WIDTH     ( DW     ),
+    .DATA_WIDTH     ( UW+DW  ),
     .BE_WIDTH       ( DW/BW  ),
     .ADDR_MEM_WIDTH ( AWM    ),
     .TEST_SET_BIT   ( TS_BIT )

--- a/rtl/interco/hci_shallow_interconnect.sv
+++ b/rtl/interco/hci_shallow_interconnect.sv
@@ -114,6 +114,7 @@ module hci_shallow_interconnect
           out[ii].be      = in_high[ii].be;
           out[ii].data    = in_high[ii].data;
           out[ii].id      = in_high[ii].id;
+          out[ii].user    = in_high[ii].user;
           in_high[ii].gnt = out[ii].gnt;
         end 
         else
@@ -124,12 +125,15 @@ module hci_shallow_interconnect
           out[ii].be     = in_low[ii].be;
           out[ii].data   = in_low[ii].data;
           out[ii].id     = in_low[ii].id;
+          out[ii].user   = in_low[ii].user;
           in_low[ii].gnt = out[ii].gnt;
         end
         in_high[ii].r_data = out[ii].r_data;
         in_low [ii].r_data = out[ii].r_data;
         in_high[ii].r_id   = out[ii].r_id;
         in_low [ii].r_id   = out[ii].r_id;
+        in_high[ii].r_user = out[ii].r_user;
+        in_low [ii].r_user = out[ii].r_user;
       end
     end // tcdm_binding
   endgenerate

--- a/rtl/mem/hci_mem_assign.sv
+++ b/rtl/mem/hci_mem_assign.sv
@@ -28,7 +28,9 @@ module hci_mem_assign
   assign tcdm_master.data   = tcdm_slave.data;
   assign tcdm_master.be     = tcdm_slave.be;
   assign tcdm_master.id     = tcdm_slave.id;
+  assign tcdm_master.user   = tcdm_slave.user;
   assign tcdm_slave.r_data  = tcdm_master.r_data;
   assign tcdm_slave.r_id    = tcdm_master.r_id;
+  assign tcdm_slave.r_user  = tcdm_master.r_user;
 
 endmodule // hci_mem_assign


### PR DESCRIPTION
This PR add optional `user` and `r_user` signals parallel to `data` and `r_data`, respectively. Width of the user signals can be set using `UW`, default is 0. Most modules are updated to support the user signals, except the following modules which ignore user inputs and set user outputs to `'0`:
- `hci_core_sink`
- `hci_core_source`
- `hci_core_split`
- `hci_hwpe_interconnect` (please note that this may adversely affect `hci_interconnect`)

There are some further modification regarding consistent addressing in the interconnects, as well as modification to default values for more consistency.