### PR TITLE
Update hci_interconnect Address Width

### DIFF
--- a/rtl/common/hci_interfaces.sv
+++ b/rtl/common/hci_interfaces.sv
@@ -91,7 +91,7 @@ interface hci_mem_intf (
 );
 
   parameter int unsigned AW = hci_package::DEFAULT_AW; /// Address Width
-  parameter int unsigned DW = hci_package::DEFAULT_DW; /// Data Width
+  parameter int unsigned DW = hci_package::DEFAULT_DW; /// Data Width (WW=DW for mem_intf)
   parameter int unsigned BW = hci_package::DEFAULT_BW; /// Width of a "byte" in bits (default 8)
   parameter int unsigned IW = 8; /// width of ID
 

--- a/rtl/common/hci_interfaces.sv
+++ b/rtl/common/hci_interfaces.sv
@@ -19,10 +19,10 @@ interface hci_core_intf (
   input logic clk
 );
 
-  parameter int unsigned DW = hci_package::DEFAULT_DW; /// data width
-  parameter int unsigned AW = hci_package::DEFAULT_AW; /// addr width
-  parameter int unsigned BW = hci_package::DEFAULT_BW; /// width of a "byte" in bits (default 8 of course)
-  parameter int unsigned WW = hci_package::DEFAULT_WW; /// width of a "word" in bits (default 32)
+  parameter int unsigned DW = hci_package::DEFAULT_DW; /// Data Width
+  parameter int unsigned AW = hci_package::DEFAULT_AW; /// Address Width
+  parameter int unsigned BW = hci_package::DEFAULT_BW; /// Width of a "byte" in bits (default 8)
+  parameter int unsigned WW = hci_package::DEFAULT_WW; /// Width of a "word" in bits (default 32)
   parameter int unsigned OW = AW; /// intra-bank offset width, defaults to addr width
 
   // handshake signals
@@ -90,10 +90,10 @@ interface hci_mem_intf (
   input logic clk
 );
 
-  parameter int unsigned AW = 32; /// addr width
-  parameter int unsigned DW = 32; /// data width
-  parameter int unsigned BW = 8;  /// width of a "byte" in bits (default 8 of course)
-  parameter int unsigned IW = 8;  /// width of ID
+  parameter int unsigned AW = hci_package::DEFAULT_AW; /// Address Width
+  parameter int unsigned DW = hci_package::DEFAULT_DW; /// Data Width
+  parameter int unsigned BW = hci_package::DEFAULT_BW; /// Width of a "byte" in bits (default 8)
+  parameter int unsigned IW = 8; /// width of ID
 
   // handshake signals
   logic req;

--- a/rtl/common/hci_package.sv
+++ b/rtl/common/hci_package.sv
@@ -15,10 +15,10 @@
 
 package hci_package;
 
-  parameter int unsigned DEFAULT_DW = 32;
-  parameter int unsigned DEFAULT_AW = 32;
-  parameter int unsigned DEFAULT_BW = 8;
-  parameter int unsigned DEFAULT_WW = 10;
+  parameter int unsigned DEFAULT_DW = 32; // Default Data Width
+  parameter int unsigned DEFAULT_AW = 32; // Default Address Width
+  parameter int unsigned DEFAULT_BW = 8;  // Default Byte Width
+  parameter int unsigned DEFAULT_WW = 32; // Default Word Width
 
   typedef struct packed {
     logic [1:0] arb_policy;

--- a/rtl/core/hci_core_load_store_mixer.sv
+++ b/rtl/core/hci_core_load_store_mixer.sv
@@ -18,10 +18,10 @@ import hci_package::*;
 
 module hci_core_load_store_mixer
 #(
-  parameter int unsigned DW = 32,
-  parameter int unsigned AW = 32,
-  parameter int unsigned BW = 8,
-  parameter int unsigned WW = 32,
+  parameter int unsigned DW = hci_package::DEFAULT_DW,
+  parameter int unsigned AW = hci_package::DEFAULT_AW,
+  parameter int unsigned BW = hci_package::DEFAULT_BW,
+  parameter int unsigned WW = hci_package::DEFAULT_WW,
   parameter int unsigned OW = 1
 )
 (

--- a/rtl/core/hci_core_memmap_demux_interl.sv
+++ b/rtl/core/hci_core_memmap_demux_interl.sv
@@ -18,8 +18,9 @@ import hwpe_stream_package::*;
 
 module hci_core_memmap_demux_interl #(
   parameter int unsigned NB_REGION = 2,
-  parameter int unsigned AW  = 32, /// addr width
-  parameter int unsigned AWC = 32  /// addr width core (useful part!)
+  parameter int unsigned AW  = hci_package::DEFAULT_AW, /// addr width
+  parameter int unsigned AWC = hci_package::DEFAULT_AW, /// addr width core (useful part!)
+  parameter int unsigned DW  = hci_package::DEFAULT_DW
 )
 (
   input  logic         clk_i,
@@ -38,10 +39,10 @@ module hci_core_memmap_demux_interl #(
     logic [$clog2(NB_REGION)-1:0] region_d, region_q;
     logic region_sample;
 
-    logic [NB_REGION-1:0]       master_req_aux, master_gnt_aux;
-    logic [NB_REGION-1:0]       master_r_valid_aux;
-    logic [NB_REGION-1:0][31:0] master_r_data_aux;
-    logic [NB_REGION-1:0]       master_r_opc_aux;
+    logic [NB_REGION-1:0]         master_req_aux, master_gnt_aux;
+    logic [NB_REGION-1:0]         master_r_valid_aux;
+    logic [NB_REGION-1:0][DW-1:0] master_r_data_aux;
+    logic [NB_REGION-1:0]         master_r_opc_aux;
 
     logic [NB_REGION-1:0] destination_map;
     logic                 destination_valid;

--- a/rtl/core/hci_core_memmap_filter.sv
+++ b/rtl/core/hci_core_memmap_filter.sv
@@ -19,7 +19,7 @@ import hwpe_stream_package::*;
 module hci_core_memmap_filter #(
   parameter int unsigned NB_REGION = 2,
   parameter int unsigned NB_INTERLEAVED_REGION = 1,
-  parameter int unsigned AW = 32 /// addr width
+  parameter int unsigned AW = hci_package::DEFAULT_AW /// addr width
 )
 (
   input  logic         clk_i,
@@ -145,7 +145,7 @@ module hci_core_memmap_filter #(
         end
         ERROR: begin
           slave.r_valid = 1'b1;
-          slave.r_data  = 32'hbadacce5;
+          slave.r_data  = 32'hbadacce5; // May need modification for DW != 32
           slave.r_opc   = 1;
         end
         default: begin

--- a/rtl/core/hci_core_mux_dynamic.sv
+++ b/rtl/core/hci_core_mux_dynamic.sv
@@ -51,10 +51,10 @@ module hci_core_mux_dynamic
 #(
   parameter int unsigned NB_IN_CHAN  = 2,
   parameter int unsigned NB_OUT_CHAN = 1,
-  parameter int unsigned DW = 32,
-  parameter int unsigned AW = 32,
-  parameter int unsigned BW = 8,
-  parameter int unsigned WW = 32,
+  parameter int unsigned DW = hci_package::DEFAULT_DW,
+  parameter int unsigned AW = hci_package::DEFAULT_AW,
+  parameter int unsigned BW = hci_package::DEFAULT_BW,
+  parameter int unsigned WW = hci_package::DEFAULT_WW,
   parameter int unsigned OW = 1
 )
 (

--- a/rtl/core/hci_core_sink.sv
+++ b/rtl/core/hci_core_sink.sv
@@ -19,9 +19,9 @@ import hci_package::*;
 module hci_core_sink
 #(
   // Stream interface params
-  parameter int unsigned DATA_WIDTH      = 32,
+  parameter int unsigned DATA_WIDTH      = hci_package::DEFAULT_DW,
   parameter int unsigned TCDM_FIFO_DEPTH = 0,
-  parameter int unsigned TRANS_CNT = 16
+  parameter int unsigned TRANS_CNT       = 16
 )
 (
   input logic clk_i,

--- a/rtl/core/hci_core_source.sv
+++ b/rtl/core/hci_core_source.sv
@@ -19,7 +19,7 @@ import hci_package::*;
 module hci_core_source
 #(
   // Stream interface params
-  parameter int unsigned DATA_WIDTH = 32,
+  parameter int unsigned DATA_WIDTH = hci_package::DEFAULT_DW,
   parameter int unsigned LATCH_FIFO  = 0,
   parameter int unsigned TRANS_CNT = 16,
   parameter int unsigned ADDR_MIS_DEPTH = 8 // Beware: this must be >= the maximum latency between TCDM gnt and TCDM r_valid!!!

--- a/rtl/hci_interconnect.sv
+++ b/rtl/hci_interconnect.sv
@@ -19,34 +19,35 @@
 import hci_package::*;
 
 module hci_interconnect #(
-  parameter int unsigned N_HWPE  = 4,
-  parameter int unsigned N_CORE  = 8,
-  parameter int unsigned N_DMA   = 4,
-  parameter int unsigned N_EXT   = 4,
-  parameter int unsigned N_MEM   = 16,
-  parameter int unsigned AWC     = 32,
-  parameter int unsigned AWM     = 32,
-  parameter int unsigned DW_LIC  = 32,
-  parameter int unsigned DW_SIC  = 128,
-  parameter int unsigned TS_BIT  = 21,
-  parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT,
-  parameter int unsigned EXPFIFO = 0,
-  parameter int unsigned DWH = hci_package::DEFAULT_DW,
-  parameter int unsigned AWH = hci_package::DEFAULT_AW,
-  parameter int unsigned BWH = hci_package::DEFAULT_BW,
-  parameter int unsigned WWH = hci_package::DEFAULT_WW,
-  parameter int unsigned OWH = AWH,
-  parameter int unsigned SEL_LIC = 0
+  parameter int unsigned N_HWPE  = 4                        , // Number of HWPEs attached to the port
+  parameter int unsigned N_CORE  = 8                        , // Number of Core ports
+  parameter int unsigned N_DMA   = 4                        , // Number of DMA ports
+  parameter int unsigned N_EXT   = 4                        , // Number of External ports
+  parameter int unsigned N_MEM   = 16                       , // Number of Memory banks
+  parameter int unsigned AWC     = hci_package::DEFAULT_AW  , // Address Width Core   (slave ports)
+  parameter int unsigned AWM     = hci_package::DEFAULT_AW  , // Address width memory (master ports)
+  parameter int unsigned DW_LIC  = hci_package::DEFAULT_DW  , // Data Width for Log Interconnect
+  parameter int unsigned BW_LIC  = hci_package::DEFAULT_BW  , // Byte Width for Log Interconnect
+  parameter int unsigned DW_SIC  = 128                      , // UNUSED!!!
+  parameter int unsigned TS_BIT  = 21                       , // TEST_SET_BIT (for Log Interconnect)
+  parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
+  parameter int unsigned EXPFIFO = 0                        , // FIFO Depth for HWPE Interconnect
+  parameter int unsigned DWH     = hci_package::DEFAULT_DW  , // Data Width for HWPE Interconnect
+  parameter int unsigned AWH     = hci_package::DEFAULT_AW  , // Address Width for HWPE Interconnect
+  parameter int unsigned BWH     = hci_package::DEFAULT_BW  , // Byte Width for HWPE Interconnect
+  parameter int unsigned WWH     = hci_package::DEFAULT_WW  , // Word Width for HWPE Interconnect
+  parameter int unsigned OWH     = AWH                      , // Offset Width for HWPE Interconnect
+  parameter int unsigned SEL_LIC = 0                          // Log interconnect type selector
 ) (
-  input  logic                   clk_i,
-  input  logic                   rst_ni,
-  input  logic                   clear_i,
-  input  hci_interconnect_ctrl_t ctrl_i,
-  hci_core_intf.slave            cores   [N_CORE-1:0],
-  hci_core_intf.slave            dma     [N_DMA-1:0],
-  hci_core_intf.slave            ext     [N_EXT-1:0],
-  hci_mem_intf.master            mems    [N_MEM-1:0],
-  hci_core_intf.slave            hwpe
+  input logic                   clk_i               ,
+  input logic                   rst_ni              ,
+  input logic                   clear_i             ,
+  input hci_interconnect_ctrl_t ctrl_i              ,
+  hci_core_intf.slave           cores   [N_CORE-1:0],
+  hci_core_intf.slave           dma     [N_DMA-1:0] ,
+  hci_core_intf.slave           ext     [N_EXT-1:0] ,
+  hci_mem_intf.master           mems    [N_MEM-1:0] ,
+  hci_core_intf.slave           hwpe
 );
 
   hci_core_intf all_except_hwpe [N_CORE+N_DMA+N_EXT-1:0] (
@@ -75,6 +76,7 @@ module hci_interconnect #(
         .AWC    ( AWC                 ),
         .AWM    ( AWM-2               ),
         .DW     ( DW_LIC              ),
+        .BW     ( BW_LIC              ),
         .TS_BIT ( TS_BIT              )
       ) i_log_interconnect (
         .clk_i  ( clk_i               ),
@@ -92,7 +94,8 @@ module hci_interconnect #(
         .IW     ( IW                  ),
         .AWC    ( AWC                 ),
         .AWM    ( AWM                 ),
-        .DW     ( DW_LIC              )
+        .DW     ( DW_LIC              ),
+        .BW     ( BW_LIC              )
       ) i_log_interconnect (
         .clk_i  ( clk_i               ),
         .rst_ni ( rst_ni              ),
@@ -110,6 +113,7 @@ module hci_interconnect #(
         .AWC    ( AWC                 ),
         .AWM    ( AWM-2               ),
         .DW     ( DW_LIC              ),
+        .BW     ( BW_LIC              ),
         .TS_BIT ( TS_BIT              )
       ) i_log_interconnect (
         .clk_i  ( clk_i               ),

--- a/rtl/hci_interconnect.sv
+++ b/rtl/hci_interconnect.sv
@@ -50,18 +50,30 @@ module hci_interconnect #(
   hci_core_intf.slave           hwpe
 );
 
-  hci_core_intf all_except_hwpe [N_CORE+N_DMA+N_EXT-1:0] (
+  hci_core_intf #(
+    .DW ( DW_LIC ),
+    .AW ( AWC    ),
+    .BW ( BW_LIC ),
+    .WW ( DW_LIC ),
+    .OW ( 1      )
+  ) all_except_hwpe [N_CORE+N_DMA+N_EXT-1:0] (
     .clk ( clk_i )
   );
 
   hci_mem_intf #(
-    .IW ( IW )
+    .AW ( AWM    ),
+    .DW ( DW_LIC ),
+    .BW ( BW_LIC ),
+    .IW ( IW     )
   ) all_except_hwpe_mem [N_MEM-1:0] (
     .clk ( clk_i )
   );
 
   hci_mem_intf #(
-    .IW ( IW )
+    .AW ( AWM    ),
+    .DW ( DW_LIC ),
+    .BW ( BW_LIC ),
+    .IW ( IW     )
   ) hwpe_mem [N_MEM-1:0] (
     .clk ( clk_i )
   );
@@ -74,7 +86,7 @@ module hci_interconnect #(
         .N_MEM  ( N_MEM               ),
         .IW     ( IW                  ),
         .AWC    ( AWC                 ),
-        .AWM    ( AWM-2               ),
+        .AWM    ( AWM                 ),
         .DW     ( DW_LIC              ),
         .BW     ( BW_LIC              ),
         .TS_BIT ( TS_BIT              )
@@ -111,7 +123,7 @@ module hci_interconnect #(
         .N_MEM  ( N_MEM               ),
         .IW     ( IW                  ),
         .AWC    ( AWC                 ),
-        .AWM    ( AWM-2               ),
+        .AWM    ( AWM                 ),
         .DW     ( DW_LIC              ),
         .BW     ( BW_LIC              ),
         .TS_BIT ( TS_BIT              )

--- a/rtl/interco/hci_hwpe_interconnect.sv
+++ b/rtl/interco/hci_hwpe_interconnect.sv
@@ -49,7 +49,7 @@ module hci_hwpe_interconnect
 
   //There is only one input port, but with variable data width.
   //NB_IN_CHAN states, to how many standard (32-bit) ports the input port is equivalent
-  localparam NB_IN_CHAN  = DWH / 32;
+  localparam NB_IN_CHAN  = DWH / WWH;
   //Word-interleaved scheme:
   // - First bits of requested address are shared
   // - Lowest 2 bits are byte offset within a DWORD -> ignored

--- a/rtl/interco/hci_hwpe_interconnect.sv
+++ b/rtl/interco/hci_hwpe_interconnect.sv
@@ -94,27 +94,27 @@ module hci_hwpe_interconnect
 
     // FIFOs for HWPE ports
     if(FIFO_DEPTH == 0) begin: no_fifo_gen
-    hci_core_assign i_no_fifo (
-      .tcdm_slave  ( in            ),
-      .tcdm_master ( postfifo      )
-    );
+      hci_core_assign i_no_fifo (
+        .tcdm_slave  ( in            ),
+        .tcdm_master ( postfifo      )
+      );
     end // no_fifo_gen
     else begin: fifo_gen
-    hci_core_fifo #(
-      .FIFO_DEPTH ( FIFO_DEPTH ),
-      .DW         ( DWH        ),
-      .BW         ( AWH        ),
-      .AW         ( BWH        ),
-      .WW         ( WWH        ),
-      .OW         ( OWH        )
-    ) i_fifo (
-      .clk_i       ( clk_i         ),
-      .rst_ni      ( rst_ni        ),
-      .clear_i     ( clear_i       ),
-      .flags_o     (               ),
-      .tcdm_slave  ( in            ),
-      .tcdm_master ( postfifo      )
-    );
+      hci_core_fifo #(
+        .FIFO_DEPTH ( FIFO_DEPTH ),
+        .DW         ( DWH        ),
+        .BW         ( AWH        ),
+        .AW         ( BWH        ),
+        .WW         ( WWH        ),
+        .OW         ( OWH        )
+      ) i_fifo (
+        .clk_i       ( clk_i         ),
+        .rst_ni      ( rst_ni        ),
+        .clear_i     ( clear_i       ),
+        .flags_o     (               ),
+        .tcdm_slave  ( in            ),
+        .tcdm_master ( postfifo      )
+      );
     end // fifo_gen
     
     assign bank_offset_s = postfifo.add[LSB_COMMON_ADDR-1:2];

--- a/rtl/interco/hci_log_interconnect.sv
+++ b/rtl/interco/hci_log_interconnect.sv
@@ -21,9 +21,10 @@ module hci_log_interconnect #(
   parameter int unsigned N_CH0  = 16,
   parameter int unsigned N_CH1  = 4,
   parameter int unsigned N_MEM  = 32,
-  parameter int unsigned AWC    = 32,
-  parameter int unsigned AWM    = 32,
-  parameter int unsigned DW     = 32,
+  parameter int unsigned AWC    = hci_package::DEFAULT_AW,
+  parameter int unsigned AWM    = hci_package::DEFAULT_AW,
+  parameter int unsigned DW     = hci_package::DEFAULT_DW,
+  parameter int unsigned BW     = hci_package::DEFAULT_BW,
   parameter int unsigned TS_BIT = 21,
   parameter int unsigned IW     = N_CH0+N_CH1
 ) (
@@ -33,8 +34,6 @@ module hci_log_interconnect #(
   hci_core_intf.slave            cores [N_CH0+N_CH1-1:0],
   hci_mem_intf.master            mems  [N_MEM-1:0]
 );
-
-  localparam BW = 8;
 
   // master side
   logic [N_CH0+N_CH1-1:0]             cores_req;

--- a/rtl/interco/hci_log_interconnect.sv
+++ b/rtl/interco/hci_log_interconnect.sv
@@ -46,7 +46,7 @@ module hci_log_interconnect #(
   logic [N_CH0+N_CH1-1:0] [DW-1:0]    cores_r_rdata;
   // slave side
   logic [N_MEM-1:0]             mems_req;
-  logic [N_MEM-1:0] [AWM-1:0]   mems_add;
+  logic [N_MEM-1:0] [AWM-3:0]   mems_add;
   logic [N_MEM-1:0]             mems_wen;
   logic [N_MEM-1:0] [DW-1:0]    mems_wdata;
   logic [N_MEM-1:0] [DW/BW-1:0] mems_be;
@@ -73,9 +73,8 @@ module hci_log_interconnect #(
     end // cores_unrolling
     for(genvar i=0; i<N_MEM; i++) begin : mems_unrolling
       assign mems[i].req               = mems_req   [i];
-      assign mems[i].add [AWC-3:2]     = mems_add   [i];
+      assign mems[i].add [AWM-1:2]     = mems_add   [i];
       assign mems[i].add [1:0]         = '0;
-      assign mems[i].add [AWC-1:AWC-2] = '0;
       assign mems[i].wen               = mems_wen   [i];
       assign mems[i].data              = mems_wdata [i];
       assign mems[i].be                = mems_be    [i];
@@ -110,7 +109,7 @@ module hci_log_interconnect #(
     .ADDR_WIDTH     ( AWC    ),
     .DATA_WIDTH     ( DW     ),
     .BE_WIDTH       ( DW/BW  ),
-    .ADDR_MEM_WIDTH ( AWM    ),
+    .ADDR_MEM_WIDTH ( AWM-2  ),
     .TEST_SET_BIT   ( TS_BIT )
   ) i_xbar_tcdm (
     .clk               ( clk_i             ),

--- a/rtl/interco/hci_log_interconnect_l2.sv
+++ b/rtl/interco/hci_log_interconnect_l2.sv
@@ -21,10 +21,10 @@ module hci_log_interconnect_l2 #(
   parameter int unsigned N_CH0  = 16,
   parameter int unsigned N_CH1  = 4,
   parameter int unsigned N_MEM  = 32,
-  parameter int unsigned AWC    = 32,
-  parameter int unsigned AWM    = 32,
-  parameter int unsigned DW     = 32,
-  parameter int unsigned TS_BIT = 21,
+  parameter int unsigned AWC    = hci_package::DEFAULT_AW,
+  parameter int unsigned AWM    = hci_package::DEFAULT_AW,
+  parameter int unsigned DW     = hci_package::DEFAULT_DW,
+  parameter int unsigned BW     = hci_package::DEFAULT_BW,
   parameter int unsigned IW     = N_CH0+N_CH1
 ) (
   input  logic                   clk_i,
@@ -33,8 +33,6 @@ module hci_log_interconnect_l2 #(
   hci_core_intf.slave            cores [N_CH0+N_CH1-1:0],
   hci_mem_intf.master            mems  [N_MEM-1:0]
 );
-
-  localparam BW = 8;
 
   // master side
   logic [N_CH0+N_CH1-1:0]             cores_req;

--- a/rtl/interco/hci_new_log_interconnect.sv
+++ b/rtl/interco/hci_new_log_interconnect.sv
@@ -46,7 +46,7 @@ module hci_new_log_interconnect #(
   logic [N_CH0+N_CH1-1:0] [DW-1:0]    cores_r_rdata;
   // slave side
   logic [N_MEM-1:0]             mems_req;
-  logic [N_MEM-1:0] [AWM-1:0]   mems_add;
+  logic [N_MEM-1:0] [AWM-3:0]   mems_add;
   logic [N_MEM-1:0]             mems_wen;
   logic [N_MEM-1:0] [DW-1:0]    mems_wdata;
   logic [N_MEM-1:0] [DW/BW-1:0] mems_be;
@@ -73,9 +73,8 @@ module hci_new_log_interconnect #(
     end // cores_unrolling
     for(genvar i=0; i<N_MEM; i++) begin : mems_unrolling
       assign mems[i].req               = mems_req   [i];
-      assign mems[i].add [AWC-3:2]     = mems_add   [i];
+      assign mems[i].add [AWM-1:2]     = mems_add   [i];
       assign mems[i].add [1:0]         = '0;
-      assign mems[i].add [AWC-1:AWC-2] = '0;
       assign mems[i].wen               = mems_wen   [i];
       assign mems[i].data              = mems_wdata [i];
       assign mems[i].be                = mems_be    [i];
@@ -110,7 +109,7 @@ module hci_new_log_interconnect #(
     .ADDR_WIDTH     ( AWC    ),
     .DATA_WIDTH     ( DW     ),
     .BE_WIDTH       ( DW/BW  ),
-    .ADDR_MEM_WIDTH ( AWM    ),
+    .ADDR_MEM_WIDTH ( AWM-2  ),
     .TEST_SET_BIT   ( TS_BIT )
   ) i_xbar_tcdm (
     .clk               ( clk_i             ),

--- a/rtl/interco/hci_new_log_interconnect.sv
+++ b/rtl/interco/hci_new_log_interconnect.sv
@@ -21,9 +21,10 @@ module hci_new_log_interconnect #(
   parameter int unsigned N_CH0  = 16,
   parameter int unsigned N_CH1  = 4,
   parameter int unsigned N_MEM  = 32,
-  parameter int unsigned AWC    = 32,
-  parameter int unsigned AWM    = 32,
-  parameter int unsigned DW     = 32,
+  parameter int unsigned AWC    = hci_package::DEFAULT_AW,
+  parameter int unsigned AWM    = hci_package::DEFAULT_AW,
+  parameter int unsigned DW     = hci_package::DEFAULT_DW,
+  parameter int unsigned BW     = hci_package::DEFAULT_BW,
   parameter int unsigned TS_BIT = 21,
   parameter int unsigned IW     = N_CH0+N_CH1
 ) (
@@ -33,8 +34,6 @@ module hci_new_log_interconnect #(
   hci_core_intf.slave            cores [N_CH0+N_CH1-1:0],
   hci_mem_intf.master            mems  [N_MEM-1:0]
 );
-
-  localparam BW = 8;
 
   // master side
   logic [N_CH0+N_CH1-1:0]             cores_req;


### PR DESCRIPTION
This PR has two commits: 
one updating defaults throughout hci to remain consistent with pre-defined defaults
one making minor changes to the `ADDR_MEM_WIDTH` linked between `hci_interconnect` and `hci_log_interconnect` (and `hci_new_log_interconnect`) to have consistent widths.

@FrancescoConti if needed I can split these up as well to separate PRs, just let me know.