### PR TITLE
Fix erroneous default_uw value

### DIFF
--- a/rtl/common/hci_package.sv
+++ b/rtl/common/hci_package.sv
@@ -19,7 +19,7 @@ package hci_package;
   parameter int unsigned DEFAULT_AW = 32; // Default Address Width
   parameter int unsigned DEFAULT_BW = 8;  // Default Byte Width
   parameter int unsigned DEFAULT_WW = 32; // Default Word Width
-  parameter int unsigned DEFAULT_UW = 0;  // Default User Width
+  parameter int unsigned DEFAULT_UW = 1;  // Default User Width
 
   typedef struct packed {
     logic [1:0] arb_policy;


### PR DESCRIPTION
The default UW value in hci_package is not actually supported. This results in lots of signals having a default dimension of logic[-1:0] which is during simulation but illegal during synthesis. Without conditional declaration of the signals we cannot support UW widths of 0 therefore I changed it to the minimum value that is actually supported (1). If the user signals is not used it will hopefully be removed during logic optimization.