### PR TITLE
Fixed Bender.yml

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -44,5 +44,3 @@ sources:
       - rtl/interco/hci_hwpe_interconnect.sv
       # Level 4
       - rtl/hci_interconnect.sv
-      # Level 5
-      - rtl/hci_interconnect_wrap.sv


### PR DESCRIPTION
Removed hci_interconnect_wrap.sv dependency from Bender.yml.