### PR TITLE
Add source / sink modules for replication for error detection.

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -40,6 +40,8 @@ sources:
       - rtl/interco/hci_new_log_interconnect.sv # `new_XBAR_TCDM` dep. is a private repo
       - rtl/interco/hci_arbiter.sv
       - rtl/interco/hci_router_reorder.sv
+      - rtl/parity/hci_copy_source.sv
+      - rtl/parity/hci_copy_sink.sv
       # Level 3
       - rtl/core/hci_core_sink.sv
       - rtl/interco/hci_router.sv

--- a/rtl/common/hci_package.sv
+++ b/rtl/common/hci_package.sv
@@ -64,4 +64,11 @@ package hci_package;
     STREAMER_IDLE, STREAMER_WORKING, STREAMER_DONE
   } hci_streamer_state_t;
 
+  typedef enum {
+    COPY,        // Full copy and comparison of all signals
+    NO_ECC,      // Do not assign and compare ecc signals
+    NO_DATA,     // Do not assign and compare data signals
+    CTRL_ONLY    // Do not assign either ecc nor data signals
+  } hci_copy_t;
+
 endpackage // hci_package

--- a/rtl/parity/hci_copy_sink.sv
+++ b/rtl/parity/hci_copy_sink.sv
@@ -1,0 +1,68 @@
+/*
+ * hci_copy_sink.sv
+ * Maurus Item <itemm@student.ethz.ch>
+ *
+ * Copyright (C) 2024 ETH Zurich, University of Bologna
+ * Copyright and related rights are licensed under the Solderpad Hardware
+ * License, Version 0.51 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+ * or agreed to in writing, software, hardware and materials distributed under
+ * this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * The **hci_copy_sink** module is used to monitor an input normal hci interface
+ * stream `tcdm_main` and compare it with a copy  stream `tcdm_copy` element.
+ * Together with hci_copy_sink this allows for fault detection on a chain of
+ * HCI modules.
+ */
+
+`include "hci_helpers.svh"
+
+module hci_copy_sink
+  import hci_package::*;
+(
+  input logic           clk_i,
+  input logic           rst_ni,
+  hci_core_intf.monitor tcdm_main,
+  hci_core_intf.target  tcdm_copy,
+  output logic          fault_detected_o
+);
+
+  assign tcdm_copy.gnt      = tcdm_main.gnt;
+  assign tcdm_copy.r_data   = tcdm_main.r_data;
+  assign tcdm_copy.r_valid  = tcdm_main.r_valid;
+  assign tcdm_copy.r_user   = tcdm_main.r_user;
+  assign tcdm_copy.r_id     = tcdm_main.r_id;
+  assign tcdm_copy.r_opc    = tcdm_main.r_opc;
+  assign tcdm_copy.egnt     = tcdm_main.egnt;
+  assign tcdm_copy.r_evalid = tcdm_main.r_evalid;
+  assign tcdm_copy.r_ecc    = tcdm_main.r_ecc;
+
+  // Compare Signals
+  logic fault_detected;
+  assign fault_detected =
+    ( tcdm_main.req      != tcdm_copy.req      ) |
+    ( tcdm_main.ereq     != tcdm_copy.ereq     ) |
+    ( tcdm_main.r_eready != tcdm_copy.r_eready ) |
+    ( tcdm_main.ecc      != tcdm_copy.ecc      ) |
+    ( tcdm_main.add      != tcdm_copy.add      ) |
+    ( tcdm_main.wen      != tcdm_copy.wen      ) |
+    ( tcdm_main.data     != tcdm_copy.data     ) |
+    ( tcdm_main.be       != tcdm_copy.be       ) |
+    ( tcdm_main.r_ready  != tcdm_copy.r_ready  ) |
+    ( tcdm_main.user     != tcdm_copy.user     ) |
+    ( tcdm_main.id       != tcdm_copy.id       );
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      fault_detected_o <= '0;
+    end else begin
+      fault_detected_o <= fault_detected;
+    end
+  end
+
+endmodule // hci_copy_sink

--- a/rtl/parity/hci_copy_sink.sv
+++ b/rtl/parity/hci_copy_sink.sv
@@ -18,50 +18,89 @@
  * stream `tcdm_main` and compare it with a copy  stream `tcdm_copy` element.
  * Together with hci_copy_sink this allows for fault detection on a chain of
  * HCI modules.
+ *
+ * How "deep" the copy is can be set with the parameter COPY_TYPE.
+ * COPY_TYPE MUST match on connected sinks and sources!
+ *
+ * The available options are:
+ * - COPY:      Fully copy of everything.
+ * - NO_ECC:    No copy of ECC signals.
+ * - NO_DATA:   No copy of data signals.
+ * - CTRL_ONLY: o copy of data or ECC signals.
  */
 
 `include "hci_helpers.svh"
 
 module hci_copy_sink
-  import hci_package::*;
-(
+  import hci_package::*; 
+#(
+  parameter hci_package::hci_copy_t  COPY_TYPE = COPY,
+  parameter                   logic  DONT_CARE = 1 // Signal to use for don't care assignments
+) (
   input logic           clk_i,
   input logic           rst_ni,
   hci_core_intf.monitor tcdm_main,
   hci_core_intf.target  tcdm_copy,
-  output logic          fault_detected_o
+  output logic          fault_o
 );
+  
+  logic fault, ctrl_fault, data_fault, ecc_fault;
 
+  // Control signals always assigned
   assign tcdm_copy.gnt      = tcdm_main.gnt;
-  assign tcdm_copy.r_data   = tcdm_main.r_data;
   assign tcdm_copy.r_valid  = tcdm_main.r_valid;
   assign tcdm_copy.r_user   = tcdm_main.r_user;
   assign tcdm_copy.r_id     = tcdm_main.r_id;
   assign tcdm_copy.r_opc    = tcdm_main.r_opc;
-  assign tcdm_copy.egnt     = tcdm_main.egnt;
-  assign tcdm_copy.r_evalid = tcdm_main.r_evalid;
-  assign tcdm_copy.r_ecc    = tcdm_main.r_ecc;
 
-  // Compare Signals
-  logic fault_detected;
-  assign fault_detected =
+  assign ctrl_fault = 
     ( tcdm_main.req      != tcdm_copy.req      ) |
-    ( tcdm_main.ereq     != tcdm_copy.ereq     ) |
-    ( tcdm_main.r_eready != tcdm_copy.r_eready ) |
-    ( tcdm_main.ecc      != tcdm_copy.ecc      ) |
     ( tcdm_main.add      != tcdm_copy.add      ) |
     ( tcdm_main.wen      != tcdm_copy.wen      ) |
-    ( tcdm_main.data     != tcdm_copy.data     ) |
     ( tcdm_main.be       != tcdm_copy.be       ) |
     ( tcdm_main.r_ready  != tcdm_copy.r_ready  ) |
     ( tcdm_main.user     != tcdm_copy.user     ) |
     ( tcdm_main.id       != tcdm_copy.id       );
 
+
+  // Data
+  if (COPY_TYPE == NO_DATA || COPY_TYPE == CTRL_ONLY) begin
+    assign data_fault = 1'b0;
+    assign tcdm_copy.r_data = DONT_CARE;
+  end
+  else begin
+    assign tcdm_copy.r_data = tcdm_main.r_data;
+    assign data_fault = tcdm_main.data != tcdm_copy.data;
+  end
+
+
+  // ECC
+  if (COPY_TYPE == NO_ECC || COPY_TYPE == CTRL_ONLY) begin
+    assign ecc_fault = 1'b0;
+    assign tcdm_copy.egnt     = DONT_CARE;
+    assign tcdm_copy.r_evalid = DONT_CARE;
+    assign tcdm_copy.r_ecc    = DONT_CARE;
+  end
+  else begin
+    assign tcdm_copy.egnt     = tcdm_main.egnt;
+    assign tcdm_copy.r_evalid = tcdm_main.r_evalid;
+    assign tcdm_copy.r_ecc    = tcdm_main.r_ecc;
+
+    assign ecc_fault =
+      ( tcdm_main.ereq     != tcdm_copy.ereq     ) |
+      ( tcdm_main.r_eready != tcdm_copy.r_eready ) |
+      ( tcdm_main.ecc      != tcdm_copy.ecc      );
+  end
+
+
+  assign fault = ctrl_fault | data_fault | ecc_fault;
+  
+  // Store in FF so critical path is broken
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      fault_detected_o <= '0;
+      fault_o <= '0;
     end else begin
-      fault_detected_o <= fault_detected;
+      fault_o <= fault;
     end
   end
 

--- a/rtl/parity/hci_copy_source.sv
+++ b/rtl/parity/hci_copy_source.sv
@@ -1,0 +1,68 @@
+/*
+ * hci_core_assign.sv
+ * Maurus Item <itemm@student.ethz.ch>
+ *
+ * Copyright (C) 2024 ETH Zurich, University of Bologna
+ * Copyright and related rights are licensed under the Solderpad Hardware
+ * License, Version 0.51 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+ * or agreed to in writing, software, hardware and materials distributed under
+ * this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * The **hci_copy_source** module is used to monitor an input hci interface
+ * stream `tcdm_main` and copy it to an output hci interface `tcdm_copy`.
+ * Together with hci_copy_sink this allows for fault detection on a chain of
+ * HCI modules.
+ */
+
+
+`include "hci_helpers.svh"
+
+module hci_copy_source
+  import hci_package::*;
+(
+  input logic             clk_i,
+  input logic             rst_ni,
+  hci_core_intf.monitor   tcdm_main,
+  hci_core_intf.initiator tcdm_copy,
+  output logic            fault_detected_o
+);
+
+  assign tcdm_copy.req      = tcdm_main.req;
+  assign tcdm_copy.ereq     = tcdm_main.ereq;
+  assign tcdm_copy.r_eready = tcdm_main.r_eready;
+  assign tcdm_copy.ecc      = tcdm_main.ecc;
+  assign tcdm_copy.add      = tcdm_main.add;
+  assign tcdm_copy.wen      = tcdm_main.wen;
+  assign tcdm_copy.data     = tcdm_main.data;
+  assign tcdm_copy.be       = tcdm_main.be;
+  assign tcdm_copy.r_ready  = tcdm_main.r_ready;
+  assign tcdm_copy.user     = tcdm_main.user;
+  assign tcdm_copy.id       = tcdm_main.id;
+
+  // Compare Signals
+  assign fault_detected =
+    ( tcdm_copy.gnt      != tcdm_main.gnt      ) |
+    ( tcdm_copy.r_data   != tcdm_main.r_data   ) |
+    ( tcdm_copy.r_valid  != tcdm_main.r_valid  ) |
+    ( tcdm_copy.r_user   != tcdm_main.r_user   ) |
+    ( tcdm_copy.r_id     != tcdm_main.r_id     ) |
+    ( tcdm_copy.r_opc    != tcdm_main.r_opc    ) |
+    ( tcdm_copy.egnt     != tcdm_main.egnt     ) |
+    ( tcdm_copy.r_evalid != tcdm_main.r_evalid ) |
+    ( tcdm_copy.r_ecc    != tcdm_main.r_ecc    );
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      fault_detected_o <= '0;
+    end else begin
+      fault_detected_o <= fault_detected;
+    end
+  end
+
+endmodule // hci_copy_source

--- a/rtl/parity/hci_copy_source.sv
+++ b/rtl/parity/hci_copy_source.sv
@@ -18,50 +18,89 @@
  * stream `tcdm_main` and copy it to an output hci interface `tcdm_copy`.
  * Together with hci_copy_sink this allows for fault detection on a chain of
  * HCI modules.
+ *
+ * How "deep" the copy is can be set with the parameter COPY_TYPE.
+ * COPY_TYPE MUST match on connected sinks and sources!
+ *
+ * The available options are:
+ * - COPY:      Fully copy of everything.
+ * - NO_ECC:    No copy of ECC signals.
+ * - NO_DATA:   No copy of data signals.
+ * - CTRL_ONLY: o copy of data or ECC signals.
  */
-
 
 `include "hci_helpers.svh"
 
 module hci_copy_source
   import hci_package::*;
-(
+#(
+  parameter hci_package::hci_copy_t  COPY_TYPE = COPY,
+  parameter                   logic  DONT_CARE = 1 // Signal to use for don't care assignments
+) (
   input logic             clk_i,
   input logic             rst_ni,
   hci_core_intf.monitor   tcdm_main,
   hci_core_intf.initiator tcdm_copy,
-  output logic            fault_detected_o
+  output logic            fault_o
 );
+  
+  logic fault, ctrl_fault, data_fault, ecc_fault;
 
-  assign tcdm_copy.req      = tcdm_main.req;
-  assign tcdm_copy.ereq     = tcdm_main.ereq;
-  assign tcdm_copy.r_eready = tcdm_main.r_eready;
-  assign tcdm_copy.ecc      = tcdm_main.ecc;
-  assign tcdm_copy.add      = tcdm_main.add;
-  assign tcdm_copy.wen      = tcdm_main.wen;
-  assign tcdm_copy.data     = tcdm_main.data;
-  assign tcdm_copy.be       = tcdm_main.be;
-  assign tcdm_copy.r_ready  = tcdm_main.r_ready;
-  assign tcdm_copy.user     = tcdm_main.user;
-  assign tcdm_copy.id       = tcdm_main.id;
+  // Control signals always assigned
+  assign tcdm_copy.req     = tcdm_main.req;
+  assign tcdm_copy.add     = tcdm_main.add;
+  assign tcdm_copy.wen     = tcdm_main.wen;
+  assign tcdm_copy.be      = tcdm_main.be;
+  assign tcdm_copy.r_ready = tcdm_main.r_ready;
+  assign tcdm_copy.user    = tcdm_main.user;
+  assign tcdm_copy.id      = tcdm_main.id;
 
-  // Compare Signals
-  assign fault_detected =
-    ( tcdm_copy.gnt      != tcdm_main.gnt      ) |
-    ( tcdm_copy.r_data   != tcdm_main.r_data   ) |
-    ( tcdm_copy.r_valid  != tcdm_main.r_valid  ) |
-    ( tcdm_copy.r_user   != tcdm_main.r_user   ) |
-    ( tcdm_copy.r_id     != tcdm_main.r_id     ) |
-    ( tcdm_copy.r_opc    != tcdm_main.r_opc    ) |
-    ( tcdm_copy.egnt     != tcdm_main.egnt     ) |
-    ( tcdm_copy.r_evalid != tcdm_main.r_evalid ) |
-    ( tcdm_copy.r_ecc    != tcdm_main.r_ecc    );
+  assign ctrl_fault = 
+    ( tcdm_main.gnt      != tcdm_copy.gnt     ) |
+    ( tcdm_main.r_valid  != tcdm_copy.r_valid ) |
+    ( tcdm_main.r_user   != tcdm_copy.r_user  ) |
+    ( tcdm_main.r_id     != tcdm_copy.r_id    ) |
+    ( tcdm_main.r_opc    != tcdm_copy.r_opc   );
 
+
+  // Data
+  if (COPY_TYPE == NO_DATA || COPY_TYPE == CTRL_ONLY) begin
+    assign data_fault = 1'b0;
+    assign tcdm_copy.data = DONT_CARE;
+  end
+  else begin
+    assign tcdm_copy.data = tcdm_main.data;
+    assign data_fault = tcdm_main.r_data != tcdm_copy.r_data;
+  end
+
+
+  // ECC
+  if (COPY_TYPE == NO_ECC || COPY_TYPE == CTRL_ONLY) begin
+    assign ecc_fault = 1'b0;
+    assign tcdm_copy.ereq     = DONT_CARE;
+    assign tcdm_copy.r_eready = DONT_CARE;
+    assign tcdm_copy.ecc      = DONT_CARE;
+  end
+  else begin
+    assign tcdm_copy.ereq     = tcdm_main.ereq;
+    assign tcdm_copy.r_eready = tcdm_main.r_eready;
+    assign tcdm_copy.ecc      = tcdm_main.ecc;
+
+    assign ecc_fault =
+      ( tcdm_main.egnt     != tcdm_copy.egnt     ) |
+      ( tcdm_main.r_evalid != tcdm_copy.r_evalid ) |
+      ( tcdm_main.r_ecc    != tcdm_copy.r_ecc    );
+  end
+
+
+  assign fault = ctrl_fault | data_fault | ecc_fault;
+
+  // Store in FF so critical path is broken
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      fault_detected_o <= '0;
+      fault_o <= '0;
     end else begin
-      fault_detected_o <= fault_detected;
+      fault_o <= fault;
     end
   end
 

--- a/src_files.yml
+++ b/src_files.yml
@@ -30,6 +30,8 @@ hci:
     - rtl/interco/hci_new_log_interconnect.sv # `new_XBAR_TCDM` dep. is a private repo
     - rtl/interco/hci_arbiter.sv
     - rtl/interco/hci_router_reorder.sv
+    - rtl/parity/hci_copy_source.sv
+    - rtl/parity/hci_copy_sink.sv
     # Level 3
     - rtl/core/hci_core_sink.sv
     - rtl/interco/hci_router.sv


### PR DESCRIPTION
This PR adds two modules to "copy" a HCI stream so that a secundary HCI network can be built for error detection on both control and data. These modules can work together with similar modules for HWPE-Stream, where the Idea is explained more in detail https://github.com/pulp-platform/hwpe-stream/pull/21 

Currently the PR only implements the "copy" variety (see HWPE PR for definition) of replication modules. For the redundancy in RedMulE this is the only module required.
If the other varieties could be usefull elsewhere I could implement them as well, but since they would result in different parameterizations of HCI for the copy network as existing modules would have to be looked at too, while copy is "safe" with respect to other modules.