### PR TITLE
[update] optimize bandwidth for multiplexed aligned and misaligned sources

### DIFF
--- a/rtl/core/hci_core_source.sv
+++ b/rtl/core/hci_core_source.sv
@@ -1,6 +1,7 @@
 /*
  * hci_core_source.sv
  * Francesco Conti <f.conti@unibo.it>
+ * Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  *
  * Copyright (C) 2014-2022 ETH Zurich, University of Bologna
  * Copyright and related rights are licensed under the Solderpad Hardware
@@ -193,7 +194,7 @@ module hci_core_source
       stream_data_aligned = '0;
       case(addr_misaligned_q)
         2'b00: begin
-          stream_data_aligned[DATA_WIDTH-32-1:0] = stream_data_misaligned[DATA_WIDTH-32-1:0];
+          stream_data_aligned[DATA_WIDTH-1:0] = stream_data_misaligned[DATA_WIDTH-1:0];
         end
         2'b01: begin
           stream_data_aligned[DATA_WIDTH-32-1:0] = stream_data_misaligned[DATA_WIDTH-24-1:8];


### PR DESCRIPTION


There could be scenarios where aligned as well as misaligned sources multiplexed through a single source. The data received from the HCI is always one word more. If there are strictly aligned sources for example weight in Neureka[TP_IN=32], then they can benefit from the additional bandwidth[TP_IN*9=288b]. Thus, in the aligned case we can provide the whole DATA_WIDTH data to the downstream and it is upto the the downstream sink to slice data according to its requirement.