### PR TITLE
Added parameter pass-trough to HCI Core Source and Sink.

### DIFF
--- a/rtl/core/hci_core_sink.sv
+++ b/rtl/core/hci_core_sink.sv
@@ -86,7 +86,8 @@ module hci_core_sink
   parameter int unsigned TCDM_FIFO_DEPTH = 0,
   parameter int unsigned TRANS_CNT       = 16,
   parameter int unsigned MISALIGNED_ACCESSES = 1,
-  parameter hci_size_parameter_t `HCI_SIZE_PARAM(tcdm) = '0
+  parameter hci_size_parameter_t `HCI_SIZE_PARAM(tcdm) = '0,
+  parameter bit [2:0] DIM_ENABLE_1H = 3'b011 // Number of dimensions enabled in the address generator
 )
 (
   input logic clk_i,
@@ -138,7 +139,9 @@ module hci_core_sink
   };
   `HCI_INTF(tcdm_target, clk_i);
 
-  hwpe_stream_addressgen_v3 i_addressgen (
+  hwpe_stream_addressgen_v3 #(
+    .DIM_ENABLE_1H ( DIM_ENABLE_1H )
+  ) i_addressgen (
     .clk_i       ( clk_i                    ),
     .rst_ni      ( rst_ni                   ),
     .enable_i    ( address_gen_en           ),

--- a/rtl/core/hci_core_source.sv
+++ b/rtl/core/hci_core_source.sv
@@ -96,7 +96,8 @@ module hci_core_source
   parameter int unsigned ADDR_MIS_DEPTH = 8, // Beware: this must be >= the maximum latency between TCDM gnt and TCDM r_valid!!!
   parameter int unsigned MISALIGNED_ACCESSES = 1,
   parameter int unsigned PASSTHROUGH_FIFO = 0,
-  parameter hci_size_parameter_t `HCI_SIZE_PARAM(tcdm) = '0
+  parameter hci_size_parameter_t `HCI_SIZE_PARAM(tcdm) = '0,
+  parameter bit [2:0] DIM_ENABLE_1H = 3'b011 // Number of dimensions enabled in the address generator
 )
 (
   input logic clk_i,
@@ -136,7 +137,9 @@ module hci_core_source
   );
 
   // generate addresses
-  hwpe_stream_addressgen_v3 i_addressgen (
+  hwpe_stream_addressgen_v3 #(
+    .DIM_ENABLE_1H ( DIM_ENABLE_1H )
+  ) i_addressgen (
     .clk_i       ( clk_i                    ),
     .rst_ni      ( rst_ni                   ),
     .enable_i    ( address_gen_en           ),


### PR DESCRIPTION
This PR simply passes a paramter down to the HWPE Stream addressgen so that one can define how many dimensions to use in hardware and the changes for the HWPE Stream Adressgenerator are propperly backwards compatible.

See: https://github.com/pulp-platform/hwpe-stream/pull/20