### PR TITLE
Disable assertions for VCS

### DIFF
--- a/rtl/common/hci_interfaces.sv
+++ b/rtl/common/hci_interfaces.sv
@@ -142,6 +142,7 @@ interface hci_core_intf (
 
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
 
   logic clk_assert;
   always @(clk)
@@ -197,6 +198,7 @@ interface hci_core_intf (
 
   HCI_RSP5: assert property(hci_rsp5_noretire_rule)
     else `HCI_ASSERT_SEVERITY("HCI RSP-5 NORETIRE protocol violation!", 1);
+`endif
 `endif
 `endif
 

--- a/rtl/core/hci_core_fifo.sv
+++ b/rtl/core/hci_core_fifo.sv
@@ -356,6 +356,7 @@ module hci_core_fifo
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
   initial
     dw : assert(tcdm_target.DW == tcdm_initiator.DW);
   initial
@@ -373,6 +374,7 @@ module hci_core_fifo
 
   `HCI_SIZE_CHECK_ASSERTS(tcdm_initiator);
 
+`endif
 `endif
 `endif
 

--- a/rtl/core/hci_core_mux_dynamic.sv
+++ b/rtl/core/hci_core_mux_dynamic.sv
@@ -286,6 +286,7 @@ module hci_core_mux_dynamic
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
   for(genvar i=1; i<NB_IN_CHAN; i++) begin
     initial
       dw :  assert(in[i].DW  == in[0].DW);
@@ -321,6 +322,7 @@ module hci_core_mux_dynamic
 
   `HCI_SIZE_CHECK_ASSERTS_EXPLICIT_PARAM(`HCI_SIZE_PARAM(in), in[0]);
 
+`endif
 `endif
 `endif;
 

--- a/rtl/core/hci_core_mux_ooo.sv
+++ b/rtl/core/hci_core_mux_ooo.sv
@@ -232,6 +232,7 @@ module hci_core_mux_ooo
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
   for(genvar i=0; i<NB_CHAN; i++) begin
     initial
       dw :  assert(in[i].DW  == out.DW);
@@ -253,6 +254,7 @@ module hci_core_mux_ooo
 
   `HCI_SIZE_CHECK_ASSERTS(out);
 
+`endif
 `endif
 `endif;
 

--- a/rtl/core/hci_core_mux_static.sv
+++ b/rtl/core/hci_core_mux_static.sv
@@ -137,6 +137,7 @@ module hci_core_mux_static
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
   for(genvar i=0; i<NB_CHAN; i++) begin
     initial
       dw :  assert(in[i].DW  == out.DW);
@@ -154,6 +155,7 @@ module hci_core_mux_static
 
   `HCI_SIZE_CHECK_ASSERTS_EXPLICIT_PARAM(`HCI_SIZE_PARAM(in), in[0]);
 
+`endif
 `endif
 `endif;
 

--- a/rtl/core/hci_core_r_id_filter.sv
+++ b/rtl/core/hci_core_r_id_filter.sv
@@ -98,6 +98,7 @@ module hci_core_r_id_filter
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
   // gnt=1 & wen=1 => the following cycle r_valid=1
   property p_gnt_wen_high_then_r_valid_high_next_cycle;
     @(posedge clk_i) (tcdm_initiator.gnt && tcdm_initiator.wen) |-> ##1 tcdm_initiator.r_valid;
@@ -115,12 +116,14 @@ module hci_core_r_id_filter
     else $warning("`r_valid` did not follow `gnt` by 1 cycle in a read: are you sure the `r_id` filter is at the 1-cycle latency boundary?");
 `endif
 `endif
+`endif
 
 /*
  * Interface size asserts
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
   initial
     dw : assert(tcdm_target.DW == tcdm_initiator.DW);
   initial
@@ -135,6 +138,7 @@ module hci_core_r_id_filter
     ehw : assert(tcdm_target.EHW == tcdm_initiator.EHW);
   
   `HCI_SIZE_CHECK_ASSERTS(tcdm_target);
+`endif
 `endif
 `endif;
 

--- a/rtl/core/hci_core_r_valid_filter.sv
+++ b/rtl/core/hci_core_r_valid_filter.sv
@@ -94,6 +94,7 @@ module hci_core_r_valid_filter
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
   initial
     dw : assert(tcdm_target.DW == tcdm_initiator.DW);
   initial
@@ -110,6 +111,7 @@ module hci_core_r_valid_filter
     ehw : assert(tcdm_target.EHW == tcdm_initiator.EHW);
   
   `HCI_SIZE_CHECK_ASSERTS(tcdm_target);
+`endif
 `endif
 `endif;
 

--- a/rtl/core/hci_core_sink.sv
+++ b/rtl/core/hci_core_sink.sv
@@ -339,6 +339,7 @@ module hci_core_sink
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
   if(MISALIGNED_ACCESSES == 0) begin
     initial
       dw :  assert(stream.DATA_WIDTH == tcdm.DW);
@@ -349,6 +350,7 @@ module hci_core_sink
   end
   
   `HCI_SIZE_CHECK_ASSERTS(tcdm);
+`endif
 `endif
 `endif
 

--- a/rtl/core/hci_core_source.sv
+++ b/rtl/core/hci_core_source.sv
@@ -360,6 +360,7 @@ module hci_core_source
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
   if(MISALIGNED_ACCESSES == 0) begin
     initial
       dw :  assert(stream.DATA_WIDTH == tcdm.DW);
@@ -370,6 +371,7 @@ module hci_core_source
   end
   
   `HCI_SIZE_CHECK_ASSERTS(tcdm);
+`endif
 `endif
 `endif
 

--- a/rtl/core/hci_core_split.sv
+++ b/rtl/core/hci_core_split.sv
@@ -292,6 +292,7 @@ module hci_core_split
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
   for(genvar i=0; i<NB_OUT_CHAN; i++) begin
     initial
       aw :  assert(tcdm_initiator[i].AW  == tcdm_target.AW);
@@ -304,6 +305,7 @@ module hci_core_split
   end
   
   `HCI_SIZE_CHECK_ASSERTS(tcdm_target);
+`endif
 `endif
 `endif;
 

--- a/rtl/hci_interconnect.sv
+++ b/rtl/hci_interconnect.sv
@@ -272,11 +272,13 @@ module hci_interconnect
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
 
   `HCI_SIZE_CHECK_ASSERTS(hwpe);
   `HCI_SIZE_CHECK_ASSERTS_EXPLICIT_PARAM(`HCI_SIZE_PARAM(cores), cores[0]);
   `HCI_SIZE_CHECK_ASSERTS_EXPLICIT_PARAM(`HCI_SIZE_PARAM(mems), mems[0]);
   
+`endif
 `endif
 `endif;
 

--- a/rtl/interco/hci_log_interconnect_l2.sv
+++ b/rtl/interco/hci_log_interconnect_l2.sv
@@ -144,10 +144,12 @@ module hci_log_interconnect_l2
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
   for(genvar ii=0; ii<N_MEM; ii++) begin
     initial
       r_valid_tied_high : assert(mems[ii].r_valid == 1'b1);
   end
+`endif
 `endif
 `endif;
 

--- a/rtl/interco/hci_router.sv
+++ b/rtl/interco/hci_router.sv
@@ -276,6 +276,7 @@ module hci_router
  */
 `ifndef SYNTHESIS
 `ifndef VERILATOR
+`ifndef VCS
 
   initial
     assert (NB_IN_CHAN <= NB_OUT_CHAN)             else  $fatal("NB_IN_CHAN > NB_OUT_CHAN!");
@@ -289,6 +290,7 @@ module hci_router
   `HCI_SIZE_CHECK_ASSERTS_EXPLICIT_PARAM(`HCI_SIZE_PARAM(virt_in),  virt_in[0]);
   `HCI_SIZE_CHECK_ASSERTS_EXPLICIT_PARAM(`HCI_SIZE_PARAM(virt_out), virt_out[0]);
   
+`endif
 `endif
 `endif;
 


### PR DESCRIPTION
This PR disables assertions for VCS similar to Verilator. The problem with VCS was encountered in the Snitch cluster with ITA.