### PR TITLE
Fix range underflows in logic vectors

### DIFF
--- a/rtl/common/hci_interfaces.sv
+++ b/rtl/common/hci_interfaces.sv
@@ -26,6 +26,9 @@
 interface hci_core_intf (
   input logic clk
 );
+
+  import hci_package::*;
+
 `ifndef SYNTHESIS
   parameter bit WAIVE_RQ3_ASSERT  = 1'b0;
   parameter bit WAIVE_RQ4_ASSERT  = 1'b0;
@@ -52,24 +55,24 @@ interface hci_core_intf (
   logic             wen; // wen=1'b1 for LOAD, wen=1'b0 for STORE
   logic [DW-1:0]    data;
   logic [DW/BW-1:0] be;
-  logic [UW-1:0]    user;
-  logic [IW-1:0]    id;
+  logic [hci_package::iomsb(UW):0]    user;
+  logic [hci_package::iomsb(IW):0]    id;
 
   // response phase payload
   logic [DW-1:0] r_data;
-  logic [UW-1:0] r_user;
-  logic [IW-1:0] r_id;
+  logic [hci_package::iomsb(UW):0] r_user;
+  logic [hci_package::iomsb(IW):0] r_id;
   logic          r_opc;
 
   // data ECC signals
-  logic [EW-1:0] ecc;
-  logic [EW-1:0] r_ecc;
+  logic [hci_package::iomsb(EW):0] ecc;
+  logic [hci_package::iomsb(EW):0] r_ecc;
 
   // handshake ECC signals
-  logic [EHW-1:0] ereq;
-  logic [EHW-1:0] egnt;
-  logic [EHW-1:0] r_evalid;
-  logic [EHW-1:0] r_eready;
+  logic [hci_package::iomsb(EHW):0] ereq;
+  logic [hci_package::iomsb(EHW):0] egnt;
+  logic [hci_package::iomsb(EHW):0] r_evalid;
+  logic [hci_package::iomsb(EHW):0] r_eready;
 
   modport initiator (
     output req,
@@ -154,7 +157,7 @@ interface hci_core_intf (
   property hci_rq3_stability_rule;
     @(posedge clk_assert)
     ($past(req) & ~($past(req) & $past(gnt))) |-> (
-      (data == $past(data)) && 
+      (data == $past(data)) &&
       (add  == $past(add))  &&
       (wen  == $past(wen))  &&
       (be   == $past(be))   &&
@@ -174,7 +177,7 @@ interface hci_core_intf (
   property hci_rsp3_stability_rule;
     @(posedge clk_assert)
     ($past(r_valid) & ~($past(r_valid) & $past(r_ready))) |-> (
-      (r_data == $past(r_data)) && 
+      (r_data == $past(r_data)) &&
       (r_user == $past(r_user)) &&
       (r_ecc  == $past(r_ecc))  &&
       (r_id   == $past(r_id))
@@ -226,23 +229,23 @@ interface hci_mem_intf (
   logic             wen;   // wen=1'b1 for LOAD, wen=1'b0 for STORE
   logic [DW-1:0]    data;
   logic [DW/BW-1:0] be;
-  logic [IW-1:0]    id;
-  logic [UW-1:0]    user;
+  logic [hci_package::iomsb(IW):0]    id;
+  logic [hci_package::iomsb(UW):0]    user;
 
   // response phase payload
   logic [DW-1:0] r_data;
-  logic [IW-1:0] r_id;
-  logic [UW-1:0] r_user;
+  logic [hci_package::iomsb(IW):0] r_id;
+  logic [hci_package::iomsb(UW):0] r_user;
 
   // data ECC signals
-  logic [EW-1:0] ecc;
-  logic [EW-1:0] r_ecc;
+  logic [hci_package::iomsb(EW):0] ecc;
+  logic [hci_package::iomsb(EW):0] r_ecc;
 
   // handshake ECC signals
-  logic [EHW-1:0] ereq;
-  logic [EHW-1:0] egnt;
-  logic [EHW-1:0] r_evalid;
-  logic [EHW-1:0] r_eready;
+  logic [hci_package::iomsb(EHW):0] ereq;
+  logic [hci_package::iomsb(EHW):0] egnt;
+  logic [hci_package::iomsb(EHW):0] r_evalid;
+  logic [hci_package::iomsb(EHW):0] r_eready;
 
   modport initiator (
     output req,

--- a/rtl/common/hci_package.sv
+++ b/rtl/common/hci_package.sv
@@ -15,12 +15,17 @@
 
 package hci_package;
 
-  parameter int unsigned DEFAULT_DW  = 32; // Default Data Width
-  parameter int unsigned DEFAULT_AW  = 32; // Default Address Width
-  parameter int unsigned DEFAULT_BW  = 8;  // Default Byte Width
-  parameter int unsigned DEFAULT_UW  = 1;  // Default User Width
-  parameter int unsigned DEFAULT_IW  = 8;  // Default ID Width
-  parameter int unsigned DEFAULT_EW  = 1;  // Default ECC for Data Width
+  // Return either the argument minus 1 or 0 if 0; useful for IO vector width declaration
+  function automatic integer unsigned iomsb(input integer unsigned width);
+    return (width != 32'd0) ? unsigned'(width - 1) : 32'd0;
+  endfunction
+
+  parameter int unsigned DEFAULT_DW = 32;  // Default Data Width
+  parameter int unsigned DEFAULT_AW = 32;  // Default Address Width
+  parameter int unsigned DEFAULT_BW = 8;  // Default Byte Width
+  parameter int unsigned DEFAULT_UW = 1;  // Default User Width
+  parameter int unsigned DEFAULT_IW = 8;  // Default ID Width
+  parameter int unsigned DEFAULT_EW = 1;  // Default ECC for Data Width
   parameter int unsigned DEFAULT_EHW = 1;  // Default ECC for Handhshake Width
 
   typedef struct packed {

--- a/rtl/core/hci_core_fifo.sv
+++ b/rtl/core/hci_core_fifo.sv
@@ -258,13 +258,13 @@ module hci_core_fifo
   assign tcdm_target.gnt = stream_outgoing_push.ready;
 
   logic [AW+UW+IW+EW+DW+DW/BW+1-1:0] stream_outgoing_pop_data;
-  assign stream_outgoing_pop_data = stream_outgoing_pop.data; 
+  assign stream_outgoing_pop_data = stream_outgoing_pop.data;
 
   logic [AW-1:0]    tcdm_initiator_add;
   logic [DW-1:0]    tcdm_initiator_data;
-  logic [UW-1:0]    tcdm_initiator_user;
-  logic [IW-1:0]    tcdm_initiator_id;
-  logic [EW-1:0]    tcdm_initiator_ecc;
+  logic [hci_package::iomsb(UW):0]    tcdm_initiator_user;
+  logic [hci_package::iomsb(IW):0]    tcdm_initiator_id;
+  logic [hci_package::iomsb(EW):0]    tcdm_initiator_ecc;
   logic [DW/BW-1:0] tcdm_initiator_be;
   logic             tcdm_initiator_wen;
   assign tcdm_initiator.add  = tcdm_initiator_add;

--- a/rtl/core/hci_core_mux_ooo.sv
+++ b/rtl/core/hci_core_mux_ooo.sv
@@ -76,11 +76,11 @@ module hci_core_mux_ooo
   logic        [NB_CHAN-1:0]                    in_wen;
   logic        [NB_CHAN-1:0][DW-1:0]            in_data;
   logic        [NB_CHAN-1:0][DW/BW-1:0]         in_be;
-  logic        [NB_CHAN-1:0][UW-1:0]            in_user;
-  logic        [NB_CHAN-1:0][IW-1:0]            in_id;
-  logic        [NB_CHAN-1:0][EW-1:0]            in_ecc;
-  logic        [NB_CHAN-1:0][EHW-1:0]           in_egnt;
-  logic        [NB_CHAN-1:0][EHW-1:0]           in_r_evalid;
+  logic        [NB_CHAN-1:0][hci_package::iomsb(UW):0]            in_user;
+  logic        [NB_CHAN-1:0][hci_package::iomsb(IW):0]            in_id;
+  logic        [NB_CHAN-1:0][hci_package::iomsb(EW):0]            in_ecc;
+  logic        [NB_CHAN-1:0][hci_package::iomsb(EHW):0]           in_egnt;
+  logic        [NB_CHAN-1:0][hci_package::iomsb(EHW):0]           in_r_evalid;
 
   logic [$clog2(NB_CHAN)-1:0]              rr_counter_q;
   logic [NB_CHAN-1:0][$clog2(NB_CHAN)-1:0] rr_priority_d;

--- a/rtl/core/hci_core_mux_static.sv
+++ b/rtl/core/hci_core_mux_static.sv
@@ -69,11 +69,11 @@ module hci_core_mux_static
     logic        [NB_CHAN-1:0]                    in_wen;
     logic        [NB_CHAN-1:0][DW-1:0]            in_data;
     logic        [NB_CHAN-1:0][DW/BW-1:0]         in_be;
-    logic        [NB_CHAN-1:0][UW-1:0]            in_user;
-    logic        [NB_CHAN-1:0][IW-1:0]            in_id;
-    logic        [NB_CHAN-1:0][EW-1:0]            in_ecc;
-    logic        [NB_CHAN-1:0][EHW-1:0]           in_egnt;
-    logic        [NB_CHAN-1:0][EHW-1:0]           in_r_evalid;
+    logic        [NB_CHAN-1:0][hci_package::iomsb(UW):0]            in_user;
+    logic        [NB_CHAN-1:0][hci_package::iomsb(IW):0]            in_id;
+    logic        [NB_CHAN-1:0][hci_package::iomsb(EW):0]            in_ecc;
+    logic        [NB_CHAN-1:0][hci_package::iomsb(EHW):0]           in_egnt;
+    logic        [NB_CHAN-1:0][hci_package::iomsb(EHW):0]           in_r_evalid;
 
     for(genvar ii=0; ii<NB_CHAN; ii++) begin: tcdm_binding
 


### PR DESCRIPTION
This PR fixes the (somewhat common) slice/range underflows in logic vectors by using the `iomsb` function.
This is a requirement for simulating IPs from this package using VCS.