### PR TITLE
Prevent spurious writes when byte enable is all zero.

### DIFF
--- a/rtl/interco/hci_router_reorder.sv
+++ b/rtl/interco/hci_router_reorder.sv
@@ -185,7 +185,7 @@ module hci_router_reorder
       // bindings
       assign out[i].req  = out_req  [i];
       assign out[i].add  = out_add  [i];
-      assign out[i].wen  = out_wen  [i];
+      assign out[i].wen  = out_wen  [i] | ~(|out_be[i]);
       assign out[i].be   = out_be   [i];
       assign out[i].data = out_data [i];
       assign out[i].ecc  = out_ecc  [i];


### PR DESCRIPTION
In principle we do not want to issue a write transfer on a channel that has the byte enable at all 0. This PR uses the `be` value to filter inhibit the `wen` in the above cases, preventing spurious writes.