### PR TITLE
 Fix FIFO delay parameter propagation in HCI

### DIFF
--- a/rtl/common/hci_helpers.svh
+++ b/rtl/common/hci_helpers.svh
@@ -206,6 +206,7 @@
 `define HCI_SIZE_GET_IW(__x)  (`HCI_SIZE_PARAM(__x).IW)
 `define HCI_SIZE_GET_EW(__x)  (`HCI_SIZE_PARAM(__x).EW)
 `define HCI_SIZE_GET_EHW(__x) (`HCI_SIZE_PARAM(__x).EHW)
+`define HCI_SIZE_GET_FD(__x)  (`HCI_SIZE_PARAM(__x).FD)
 
 // Shorthand for defining a HCI interface compatible with a parameter
 `define HCI_INTF_EXPLICIT_PARAM(__name, __clk, __param) \
@@ -216,7 +217,8 @@
     .UW  ( __param.UW  ), \
     .IW  ( __param.IW  ), \
     .EW  ( __param.EW  ), \
-    .EHW ( __param.EHW ) \
+    .EHW ( __param.EHW ), \
+    .FD  ( __param.FD )   \
   ) __name ( \
     .clk ( __clk ) \
   )
@@ -231,6 +233,7 @@
   `define HCI_SIZE_GET_IW_CHECK(__x)  (__x.IW)
   `define HCI_SIZE_GET_EW_CHECK(__x)  (__x.EW)
   `define HCI_SIZE_GET_EHW_CHECK(__x) (__x.EHW)
+  `define HCI_SIZE_GET_FD_CHECK(__x)  (__x.FD)
 
   // Asserts (generic definition usable with any parameter name)
   `define HCI_SIZE_CHECK_ASSERTS_EXPLICIT_PARAM(__xparam, __xintf) \
@@ -240,7 +243,8 @@
   initial __xparam``_intf_size_check_uw  : assert(__xparam.UW  == `HCI_SIZE_GET_UW_CHECK(__xintf)); \
   initial __xparam``_intf_size_check_iw  : assert(__xparam.IW  == `HCI_SIZE_GET_IW_CHECK(__xintf)); \
   initial __xparam``_intf_size_check_ew  : assert(__xparam.EW  == `HCI_SIZE_GET_EW_CHECK(__xintf)); \
-  initial __xparam``_intf_size_check_ehw : assert(__xparam.EHW == `HCI_SIZE_GET_EHW_CHECK(__xintf))
+  initial __xparam``_intf_size_check_ehw : assert(__xparam.EHW == `HCI_SIZE_GET_EHW_CHECK(__xintf)); \
+  initial __xparam``_intf_size_check_fd  : assert(__xparam.FD  == `HCI_SIZE_GET_FD_CHECK(__xintf))
 
   // Asserts (specialized definition for conventional param names
   `define HCI_SIZE_CHECK_ASSERTS(__intf) `HCI_SIZE_CHECK_ASSERTS_EXPLICIT_PARAM(`HCI_SIZE_PARAM(__intf), __intf)

--- a/rtl/common/hci_interfaces.sv
+++ b/rtl/common/hci_interfaces.sv
@@ -43,6 +43,7 @@ interface hci_core_intf (
   parameter int unsigned IW  = hci_package::DEFAULT_IW;  /// ID Width
   parameter int unsigned EW  = hci_package::DEFAULT_EW;  /// ECC Width
   parameter int unsigned EHW = hci_package::DEFAULT_EHW; /// Handshake ECC Width
+  parameter int unsigned FD  = hci_package::DEFAULT_FD;  /// FIFO Depth
 
   // handshake signals
   logic req;

--- a/rtl/common/hci_package.sv
+++ b/rtl/common/hci_package.sv
@@ -27,6 +27,7 @@ package hci_package;
   parameter int unsigned DEFAULT_IW = 8;  // Default ID Width
   parameter int unsigned DEFAULT_EW = 1;  // Default ECC for Data Width
   parameter int unsigned DEFAULT_EHW = 1;  // Default ECC for Handhshake Width
+  parameter int unsigned DEFAULT_FD  = 0;  // Default FIFO Depth
 
   typedef struct packed {
     int unsigned DW;
@@ -36,6 +37,7 @@ package hci_package;
     int unsigned IW;
     int unsigned EW;
     int unsigned EHW;
+    int unsigned FD;
   } hci_size_parameter_t;
 
   parameter hci_size_parameter_t DEFAULT_HCI_SIZE = '{
@@ -45,7 +47,8 @@ package hci_package;
     UW  : DEFAULT_UW,
     IW  : DEFAULT_IW,
     EW  : DEFAULT_EW,
-    EHW : DEFAULT_EHW
+    EHW : DEFAULT_EHW,
+    FD  : DEFAULT_FD
   };
 
   typedef struct packed {

--- a/rtl/core/hci_core_mux_static.sv
+++ b/rtl/core/hci_core_mux_static.sv
@@ -153,7 +153,14 @@ module hci_core_mux_static
       ehw : assert(in[i].EHW == out.EHW);
   end
 
-  `HCI_SIZE_CHECK_ASSERTS_EXPLICIT_PARAM(`HCI_SIZE_PARAM(in), in[0]);
+  initial HCI_SIZE_in_intf_size_check_dw  : assert(`HCI_SIZE_PARAM(in).DW  == in[0].DW);
+  initial HCI_SIZE_in_intf_size_check_bw  : assert(`HCI_SIZE_PARAM(in).BW  == in[0].BW);
+  initial HCI_SIZE_in_intf_size_check_aw  : assert(`HCI_SIZE_PARAM(in).AW  == in[0].AW);
+  initial HCI_SIZE_in_intf_size_check_uw  : assert(`HCI_SIZE_PARAM(in).UW  == in[0].UW);
+  initial HCI_SIZE_in_intf_size_check_iw  : assert(`HCI_SIZE_PARAM(in).IW  == in[0].IW);
+  initial HCI_SIZE_in_intf_size_check_ew  : assert(`HCI_SIZE_PARAM(in).EW  == in[0].EW);
+  initial HCI_SIZE_in_intf_size_check_ehw : assert(`HCI_SIZE_PARAM(in).EHW == in[0].EHW);
+  // initial HCI_SIZE_in_intf_size_check_fd  : assert(`HCI_SIZE_PARAM(in).FD  == in[0].FD);
 
 `endif
 `endif

--- a/rtl/ecc/hci_ecc_interconnect.sv
+++ b/rtl/ecc/hci_ecc_interconnect.sv
@@ -42,11 +42,9 @@
  *   +---------------------+-----------------------------+----------------------------------------------------------------------------------+
  *   | *IW*                | `N_HWPE+N_CORE+N_DMA+N_EXT` | ID Width.                                                                        |
  *   +---------------------+-----------------------------+----------------------------------------------------------------------------------+
- *   | *EXPFIFO*           | 0                           | Depth of HCI router FIFO.                                                        |
+ *   | *FD*                | 0                           | Depth of HCI router FIFO.                                                        |
  *   +---------------------+-----------------------------+----------------------------------------------------------------------------------+
  *   | *SEL_LIC*           | 0                           | Kind of LIC to instantiate (0=regular L1, 1=L2).                                 |
- *   +---------------------+-----------------------------+----------------------------------------------------------------------------------+
- *   | *CHUNK_SIZE*        | 32                          | Width in bits of each chunk of data to protect individually.                     |
  *   +---------------------+-----------------------------+----------------------------------------------------------------------------------+
  */
 
@@ -63,7 +61,6 @@ module hci_ecc_interconnect
   parameter int unsigned N_MEM   = 16                       , // Number of Memory banks
   parameter int unsigned TS_BIT  = 21                       , // TEST_SET_BIT (for Log Interconnect)
   parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
-  parameter int unsigned EXPFIFO = 0                        , // FIFO Depth for HWPE Interconnect
   parameter int unsigned SEL_LIC = 0                        , // Log interconnect type selector
   parameter int unsigned FILTER_WRITE_R_VALID[0:N_HWPE-1] = '{default: 0},
   parameter int unsigned CHUNK_SIZE = 32                    , // Chunk size of data to be encoded separately (HWPE branch)
@@ -98,6 +95,7 @@ module hci_ecc_interconnect
   localparam int unsigned BWH = `HCI_SIZE_GET_BW(hwpe);
   localparam int unsigned UWH = `HCI_SIZE_GET_UW(hwpe);
   localparam int unsigned EWH = `HCI_SIZE_GET_EW(hwpe);
+  localparam int unsigned FDH = `HCI_SIZE_GET_FD(hwpe);
   localparam int unsigned N_CHUNK = DWH / CHUNK_SIZE;
   localparam int unsigned EW_DW = $clog2(CHUNK_SIZE)+2;
 
@@ -362,7 +360,7 @@ module hci_ecc_interconnect
       );
 
       hci_router #(
-        .FIFO_DEPTH           ( EXPFIFO                   ),
+        .FIFO_DEPTH           ( FDH                       ),
         .NB_OUT_CHAN          ( N_MEM                     ),
         .USE_ECC              ( 1                         ),
         .FILTER_WRITE_R_VALID ( FILTER_WRITE_R_VALID[0]  ),

--- a/rtl/hci_interconnect.sv
+++ b/rtl/hci_interconnect.sv
@@ -42,7 +42,7 @@
  *   +---------------------+-----------------------------+----------------------------------------------------------------------------------+
  *   | *IW*                | `N_HWPE+N_CORE+N_DMA+N_EXT` | ID Width.                                                                        |
  *   +---------------------+-----------------------------+----------------------------------------------------------------------------------+
- *   | *EXPFIFO*           | 0                           | Depth of HCI router FIFO.                                                        |
+ *   | *FD*                | 0                           | Depth of HCI router FIFO.                                                        |
  *   +---------------------+-----------------------------+----------------------------------------------------------------------------------+
  *   | *SEL_LIC*           | 0                           | Kind of LIC to instantiate (0=regular L1, 1=L2).                                 |
  *   +---------------------+-----------------------------+----------------------------------------------------------------------------------+
@@ -60,7 +60,6 @@ module hci_interconnect
   parameter int unsigned N_MEM   = 16                       , // Number of Memory banks
   parameter int unsigned TS_BIT  = 21                       , // TEST_SET_BIT (for Log Interconnect)
   parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
-  parameter int unsigned EXPFIFO = 0                        , // FIFO Depth for HWPE Interconnect
   parameter int unsigned SEL_LIC = 0                        , // Log interconnect type selector
   parameter int unsigned FILTER_WRITE_R_VALID[0:N_HWPE-1] = '{default: 0},
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(cores) = '0,
@@ -93,6 +92,7 @@ module hci_interconnect
   localparam int unsigned BWH = `HCI_SIZE_GET_BW(hwpe);
   localparam int unsigned UWH = `HCI_SIZE_GET_UW(hwpe);
   localparam int unsigned IWH = `HCI_SIZE_GET_IW(hwpe);
+  localparam int unsigned FDH = `HCI_SIZE_GET_FD(hwpe);
 
   localparam hci_size_parameter_t `HCI_SIZE_PARAM(all_except_hwpe) = '{
     DW:  DEFAULT_DW,
@@ -101,7 +101,8 @@ module hci_interconnect
     UW:  UW_LIC,
     IW:  DEFAULT_IW,
     EW:  DEFAULT_EW,
-    EHW: DEFAULT_EHW
+    EHW: DEFAULT_EHW,
+    FD:  DEFAULT_FD
   };
   hci_core_intf #(
     .DW  ( DEFAULT_DW  ),
@@ -129,7 +130,8 @@ module hci_interconnect
     UW:  UW_LIC,
     IW:  IW,
     EW:  DEFAULT_EW,
-    EHW: DEFAULT_EHW
+    EHW: DEFAULT_EHW,
+    FD:  DEFAULT_FD
   };
   `HCI_INTF_ARRAY(all_except_hwpe_mem, clk_i, 0:N_MEM-1);
 
@@ -140,7 +142,8 @@ module hci_interconnect
     UW:  UW_LIC,
     IW:  IW,
     EW:  DEFAULT_EW,
-    EHW: DEFAULT_EHW
+    EHW: DEFAULT_EHW,
+    FD:  DEFAULT_FD
   };
   `HCI_INTF_ARRAY(hwpe_mem_muxed, clk_i, 0:N_MEM-1);
 
@@ -152,7 +155,8 @@ module hci_interconnect
     UW:  UW_LIC,
     IW:  IW,
     EW:  DEFAULT_EW,
-    EHW: DEFAULT_EHW
+    EHW: DEFAULT_EHW,
+    FD:  DEFAULT_FD
   };
   `HCI_INTF_ARRAY(hwpe_mem, clk_i, 0:N_HWPE*N_MEM-1);
 
@@ -165,7 +169,8 @@ module hci_interconnect
     .UW(UWH),
     .IW(IWH),
     .EW(DEFAULT_EW),
-    .EHW(DEFAULT_EHW)
+    .EHW(DEFAULT_EHW),
+    .FD(FDH)
   ) hwpe_to_router (
     .clk(clk_i)
   );
@@ -239,7 +244,7 @@ module hci_interconnect
       for(genvar ii=0; ii<N_HWPE; ii++) begin : hwpe_req2mem
     
         hci_router #(
-          .FIFO_DEPTH           ( EXPFIFO                   ),
+          .FIFO_DEPTH           ( FDH                       ),
           .NB_OUT_CHAN          ( N_MEM                     ),
           .FILTER_WRITE_R_VALID ( FILTER_WRITE_R_VALID[ii]  ),
           .`HCI_SIZE_PARAM(in)  ( `HCI_SIZE_PARAM(hwpe)     ),


### PR DESCRIPTION
**Summary:**
`EXPFIFO` parameter in `hci_interconnect` would introduce multicycle delays in the `r_valid` signal, but the `hci_core_r_id_filter` module would trigger incorrect assertions even when `MULTICYCLE_SUPPORT` was active. This created an inconsistency between modules where one parameter was changing what another module should check, without proper parameter propagation.

**Proposed Solution:**
1. Replaced `EXPFIFO` with `FD` (FIFO Depth) parameter: integrated FIFO depth information directly into the HCI package structures for better parameter propagation.
2. Enhanced HCI package and helpers: added `FD` parameter to `hci_size_parameter_t` struct and created helper macros for consistent parameter handling.
3. Updated interface declarations: added `FD` parameter to all `hci_core_intf` declarations throughout the system.
4. Fixed assertion logic: modified multicycle assertions to exclude `FD` parameter checks for module port interfaces.

These changes are reflected in Neureka's interface: https://github.com/pulp-platform/neureka/pull/36#issue-3347069355