### PR TITLE
Extract full data stream for misaligned access mode

### DIFF
--- a/rtl/core/hci_core_source.sv
+++ b/rtl/core/hci_core_source.sv
@@ -121,6 +121,7 @@ module hci_core_source
 
   localparam int unsigned DATA_WIDTH = `HCI_SIZE_GET_DW(tcdm);
   localparam int unsigned EHW        = `HCI_SIZE_GET_EHW(tcdm);
+  localparam int unsigned STREAM_MISALIGNED_DW = DATA_WIDTH - BANK_DATA_WIDTH;
 
   hci_streamer_state_t cs, ns;
   flags_fifo_t addr_fifo_flags;
@@ -194,14 +195,14 @@ module hci_core_source
   // this is simply exploiting the fact that we can make a wider data access than strictly necessary!
   assign stream_data_misaligned = tcdm.r_valid ? tcdm.r_data : stream_data_q; // is this strictly necessary to keep the HWPE-Stream protocol? or can be avoided with a FIFO q?
 
-  if (MISALIGNED_ACCESSES==1 ) begin : missaligned_access_gen
-    always_comb
-    begin
+  if (MISALIGNED_ACCESSES==1) begin : misaligned_access_gen
+    always_comb begin
       stream_data_aligned = '0;
-      if(addr_misaligned_q == 0)
+      if (addr_misaligned_q == 0)
         stream_data_aligned[DATA_WIDTH-1:0] = stream_data_misaligned[DATA_WIDTH-1:0];
-      else 
-        stream_data_aligned[0+:BANK_DATA_WIDTH] = stream_data_misaligned[addr_misaligned_q*ELEMENT_WIDTH+:BANK_DATA_WIDTH];
+      else begin
+        stream_data_aligned[STREAM_MISALIGNED_DW-1:0] = stream_data_misaligned[addr_misaligned_q*ELEMENT_WIDTH +: STREAM_MISALIGNED_DW];
+      end
     end
   end
   else begin

--- a/rtl/core/hci_core_source.sv
+++ b/rtl/core/hci_core_source.sv
@@ -196,10 +196,12 @@ module hci_core_source
   assign stream_data_misaligned = tcdm.r_valid ? tcdm.r_data : stream_data_q; // is this strictly necessary to keep the HWPE-Stream protocol? or can be avoided with a FIFO q?
 
   if (MISALIGNED_ACCESSES==1) begin : misaligned_access_gen
-    always_comb begin
+    always_comb
+    begin
       stream_data_aligned = '0;
-      if (addr_misaligned_q == 0)
+      if (addr_misaligned_q == 0) begin
         stream_data_aligned[DATA_WIDTH-1:0] = stream_data_misaligned[DATA_WIDTH-1:0];
+      end
       else begin
         stream_data_aligned[STREAM_MISALIGNED_DW-1:0] = stream_data_misaligned[addr_misaligned_q*ELEMENT_WIDTH +: STREAM_MISALIGNED_DW];
       end


### PR DESCRIPTION
Fix a bug in misaligned data access: previously, only BANK_DATA_WIDTH was extracted instead of the full misaligned data stream width (DATA_WIDTH - BANK_DATA_WIDTH).