### PR TITLE
Ng/hci cut

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -35,6 +35,7 @@ sources:
       # Level 2
       - rtl/core/hci_core_assign.sv
       - rtl/core/hci_core_assign_expand.sv
+      - rtl/core/hci_core_cut.sv
       - rtl/core/hci_core_fifo.sv
       - rtl/core/hci_core_mux_dynamic.sv
       - rtl/core/hci_core_mux_static.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -36,6 +36,7 @@ sources:
       # Level 2
       - rtl/core/hci_core_assign.sv
       - rtl/core/hci_core_assign_expand.sv
+      - rtl/core/hci_core_cut.sv
       - rtl/core/hci_core_fifo.sv
       - rtl/core/hci_core_mux_dynamic.sv
       - rtl/core/hci_core_mux_static.sv

--- a/rtl/core/hci_core_cut.sv
+++ b/rtl/core/hci_core_cut.sv
@@ -1,0 +1,139 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Michael Rogenmoser <michaero@iis.ee.ethz.ch>
+// Luigi Ghionda
+
+`include "hci_helpers.svh"
+
+module hci_core_cut
+  import hci_package::*;
+#(
+  parameter hci_size_parameter_t `HCI_SIZE_PARAM(in) = '0,
+  /// Bypass enable, can be individually overridden!
+  parameter bit                Bypass       = 1'b0,
+  /// Bypass enable for Request side.
+  parameter bit                BypassReq    = Bypass,
+  /// Bypass enable for Response side.
+  parameter bit                BypassRsp    = Bypass
+) (
+  input  logic     clk_i,
+  input  logic     rst_ni,
+
+  hci_core_intf.target    in,
+  hci_core_intf.initiator out
+);
+
+  localparam int unsigned AW  = `HCI_SIZE_GET_AW(in);
+  localparam int unsigned DW  = `HCI_SIZE_GET_DW(in);
+  localparam int unsigned BW  = `HCI_SIZE_GET_BW(in);
+  localparam int unsigned UW  = `HCI_SIZE_GET_UW(in);
+  localparam int unsigned IW  = `HCI_SIZE_GET_IW(in);
+  localparam int unsigned EW  = `HCI_SIZE_GET_EW(in);
+
+  localparam int unsigned REQW = AW + 1 + DW + DW/BW + UW + IW + EW;
+  localparam int unsigned RSPW = DW + UW + IW + 1 + EW;
+
+  // logic [REQW-1:0] req_payload_in, req_payload_out;
+
+  typedef struct packed {
+    logic [AW-1:0]      add;
+    logic               wen;
+    logic [DW-1:0]      data;
+    logic [DW/BW-1:0]   be;
+    logic [UW-1:0]      user;
+    logic [IW-1:0]      id;
+    logic [EW-1:0]      ecc;
+  } req_payload_t;
+
+  typedef struct packed {
+    logic [DW-1:0]      r_data;
+    logic [UW-1:0]      r_user;
+    logic [IW-1:0]      r_id;
+    logic [EW-1:0]      r_ecc;
+  } rsp_payload_t;
+
+  req_payload_t req_payload_in, req_payload_out;
+
+  assign req_payload_in = '{
+    add:  in.add,
+    wen:  in.wen,
+    data: in.data,
+    be:   in.be,
+    user: in.user,
+    id:   in.id,
+    ecc:  in.ecc
+  };
+
+  // assign req_payload_in = {in.ecc, in.id, in.user, in.be, in.data, in.wen, in.add};
+
+
+  spill_register #(
+    .T      ( req_payload_t ), // create a similar struct to be passed to the spill register
+    .Bypass ( BypassReq    )
+  ) i_reg_a (
+    .clk_i,
+    .rst_ni,
+    .valid_i ( in.req ),
+    .ready_o ( in.gnt ),
+    .data_i  ( req_payload_in   ),
+    .valid_o ( out.req ),
+    .ready_i ( out.gnt ),
+    .data_o  ( req_payload_out   )
+  );
+
+  always_comb
+  begin : out_assign
+    out.add  = req_payload_out.add;
+    out.wen  = req_payload_out.wen;
+    out.data = req_payload_out.data;
+    out.be   = req_payload_out.be;
+    out.user = req_payload_out.user;
+    out.id   = req_payload_out.id;
+    out.ecc  = req_payload_out.ecc;
+  end
+
+  // always_comb
+  // begin : out_assign
+  //   out.add = req_payload_out[AW-1:0];
+  //   out.wen = req_payload_out[AW];
+  //   out.data = req_payload_out[AW+1+DW-1:0];
+  //   out.be = req_payload_out[AW+1+DW+DW/BW-1:0];
+  //   out.user = req_payload_out[AW+1+DW+DW/BW+UW-1:0];
+  //   out.id = req_payload_out[AW+1+DW+DW/BW+UW+ID-1:0];
+  //   out.ecc = req_payload_out[AW+1+DW+DW/BW+UW+ID+ECC-1:0];
+  // end
+
+  rsp_payload_t rsp_payload_in, rsp_payload_out;
+
+  assign rsp_payload_in = '{
+    r_data: out.r_data,
+    r_user: out.r_user,
+    r_id:   out.r_id,
+    r_ecc:  out.r_ecc
+  };
+
+  spill_register #(
+    .T      ( rsp_payload_t ),
+    .Bypass ( BypassRsp    )
+  ) i_req_r (
+    .clk_i,
+    .rst_ni,
+    .valid_i ( out.r_valid     ),
+    .ready_o ( out.r_ready     ),
+    .data_i  ( rsp_payload_in  ),
+    .valid_o ( in.r_valid      ),
+    .ready_i ( in.r_ready      ),
+    .data_o  ( rsp_payload_out )
+  );
+
+  always_comb
+  begin : in_assign
+    in.r_data = rsp_payload_out.r_data;
+    in.r_user = rsp_payload_out.r_user;
+    in.r_id   = rsp_payload_out.r_id;
+    in.r_ecc  = rsp_payload_out.r_ecc;
+  end
+
+endmodule

--- a/rtl/core/hci_core_cut.sv
+++ b/rtl/core/hci_core_cut.sv
@@ -2,8 +2,8 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 
-// Michael Rogenmoser <michaero@iis.ee.ethz.ch>
-// Luigi Ghionda
+// Luigi Ghionda,    Fondazione Chips-IT    
+// Niccolò Giuliani, Fondazione Chips-IT 
 
 `include "hci_helpers.svh"
 
@@ -35,7 +35,6 @@ module hci_core_cut
   localparam int unsigned REQW = AW + 1 + DW + DW/BW + UW + IW + EW;
   localparam int unsigned RSPW = DW + UW + IW + 1 + EW;
 
-  // logic [REQW-1:0] req_payload_in, req_payload_out;
 
   typedef struct packed {
     logic [AW-1:0]      add;
@@ -66,7 +65,6 @@ module hci_core_cut
     ecc:  in.ecc
   };
 
-  // assign req_payload_in = {in.ecc, in.id, in.user, in.be, in.data, in.wen, in.add};
 
 
   spill_register #(
@@ -93,17 +91,6 @@ module hci_core_cut
     out.id   = req_payload_out.id;
     out.ecc  = req_payload_out.ecc;
   end
-
-  // always_comb
-  // begin : out_assign
-  //   out.add = req_payload_out[AW-1:0];
-  //   out.wen = req_payload_out[AW];
-  //   out.data = req_payload_out[AW+1+DW-1:0];
-  //   out.be = req_payload_out[AW+1+DW+DW/BW-1:0];
-  //   out.user = req_payload_out[AW+1+DW+DW/BW+UW-1:0];
-  //   out.id = req_payload_out[AW+1+DW+DW/BW+UW+ID-1:0];
-  //   out.ecc = req_payload_out[AW+1+DW+DW/BW+UW+ID+ECC-1:0];
-  // end
 
   rsp_payload_t rsp_payload_in, rsp_payload_out;
 

--- a/rtl/core/hci_core_cut.sv
+++ b/rtl/core/hci_core_cut.sv
@@ -1,9 +1,29 @@
-// Copyright 2023 ETH Zurich and University of Bologna.
-// Solderpad Hardware License, Version 0.51, see LICENSE for details.
-// SPDX-License-Identifier: SHL-0.51
+/*
+ * hci_core_cut.sv
+ *
+ * Luigi Ghionda    <luigi.ghionda@chips.it>
+ * Niccolò Giuliani <niccolo.giuliani@chips.it>
+ *
+ * Copyright (C) 2026 ETH Zurich, University of Bologna and Fondazione Chips-IT
+ * Copyright and related rights are licensed under the Solderpad Hardware
+ * License, Version 0.51 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+ * or agreed to in writing, software, hardware and materials distributed under
+ * this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 
-// Luigi Ghionda,    Fondazione Chips-IT    
-// Niccolò Giuliani, Fondazione Chips-IT 
+/**
+ * The hci_core_cut module implement a timing cut (pipeline register) on an HCI core
+ * interface. It inserts spill registers on both the request (initiator-to-target)
+ * and response (target-to-initiator) channels of an `hci_core_intf`, breaking
+ * long combinational paths to improve timing closure.
+ *
+ * The cut is used in `hci_interconnect` and `hci_ecc_interconnect` to optionally
+ * decouple the core, DMA, and external ports from the interconnect fabric.
+ */
 
 `include "hci_helpers.svh"
 

--- a/rtl/ecc/hci_ecc_interconnect.sv
+++ b/rtl/ecc/hci_ecc_interconnect.sv
@@ -65,7 +65,9 @@ module hci_ecc_interconnect
   parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
   parameter int unsigned EXPFIFO = 0                        , // FIFO Depth for HWPE Interconnect
   parameter int unsigned SEL_LIC = 0                        , // Log interconnect type selector
-  parameter int unsigned HCI_CUT = 0                        , // HCI CUT enable
+  parameter int unsigned CUT_CORES = 0                      , // Insert a cut in cores interconnect
+  parameter int unsigned CUT_IDMA  = 0                      , // Insert a cut in Idma interconnect
+  parameter int unsigned CUT_EXT   = 0                      , // Insert a cut in EXT interconnect
   parameter int unsigned FILTER_WRITE_R_VALID[0:N_HWPE-1] = '{default: 0},
   parameter int unsigned CHUNK_SIZE = 32                    , // Chunk size of data to be encoded separately (HWPE branch)
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(cores) = '0,
@@ -417,9 +419,10 @@ module hci_ecc_interconnect
     end
   endgenerate
 
+
   generate
     for(genvar ii=0; ii<N_CORE; ii++) begin: cores_binding
-      if (HCI_CUT) begin : hci_cut
+      if (CUT_CORES) begin : hci_cut
         hci_core_cut #(
         .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
         ) i_hci_cut (
@@ -437,16 +440,40 @@ module hci_ecc_interconnect
       end
     end : cores_binding
     for(genvar ii=0; ii<N_EXT; ii++) begin: ext_binding
+      if (CUT_IDMA) begin : hci_cut
+          hci_core_cut #(
+          .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
+          ) i_hci_cut (
+              .clk_i  ( clk_i                ),
+              .rst_ni ( rst_ni               ),
+              .in     ( ext             [ii] ),
+              .out    ( all_except_hwpe [N_CORE+ii] )
+          );
+      end 
+      else begin : no_hci_cut
       hci_core_assign i_ext_assign (
         .tcdm_target    ( ext             [ii]        ),
         .tcdm_initiator ( all_except_hwpe [N_CORE+ii] )
       );
-    end : ext_binding
+      end
+    end : ext_binding 
     for(genvar ii=0; ii<N_DMA; ii++) begin: dma_binding
-      hci_core_assign i_dma_assign (
-        .tcdm_target    ( dma             [ii]              ),
-        .tcdm_initiator ( all_except_hwpe [N_CORE+N_EXT+ii] )
-      );
+      if (CUT_EXT) begin : hci_cut
+          hci_core_cut #(
+          .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
+          ) i_hci_cut (
+              .clk_i  ( clk_i                ),
+              .rst_ni ( rst_ni               ),
+              .in     ( dma             [ii] ),
+              .out    ( all_except_hwpe [N_CORE+N_EXT+ii] )
+          );
+      end 
+      else begin : no_hci_cut
+        hci_core_assign i_dma_assign (
+          .tcdm_target    ( dma             [ii]              ),
+          .tcdm_initiator ( all_except_hwpe [N_CORE+N_EXT+ii] )
+        );
+      end
     end : dma_binding
   endgenerate
 

--- a/rtl/ecc/hci_ecc_interconnect.sv
+++ b/rtl/ecc/hci_ecc_interconnect.sv
@@ -65,6 +65,7 @@ module hci_ecc_interconnect
   parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
   parameter int unsigned EXPFIFO = 0                        , // FIFO Depth for HWPE Interconnect
   parameter int unsigned SEL_LIC = 0                        , // Log interconnect type selector
+  parameter int unsigned HCI_CUT = 0                        , // HCI CUT enable
   parameter int unsigned FILTER_WRITE_R_VALID[0:N_HWPE-1] = '{default: 0},
   parameter int unsigned CHUNK_SIZE = 32                    , // Chunk size of data to be encoded separately (HWPE branch)
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(cores) = '0,
@@ -418,23 +419,35 @@ module hci_ecc_interconnect
 
   generate
     for(genvar ii=0; ii<N_CORE; ii++) begin: cores_binding
-      hci_core_assign i_cores_assign (
-        .tcdm_target    ( cores           [ii] ),
-        .tcdm_initiator ( all_except_hwpe [ii] )
-      );
-    end // cores_binding
+      if (HCI_CUT) begin : hci_cut
+        hci_core_cut #(
+        .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
+        ) i_hci_cut (
+            .clk_i  ( clk_i                ),
+            .rst_ni ( rst_ni               ),
+            .in     ( cores           [ii] ),
+            .out    ( all_except_hwpe [ii] )
+        );
+      end
+      else begin : no_hci_cut
+        hci_core_assign i_cores_assign (
+          .tcdm_target    ( cores           [ii] ),
+          .tcdm_initiator ( all_except_hwpe [ii] )
+        );
+      end
+    end : cores_binding
     for(genvar ii=0; ii<N_EXT; ii++) begin: ext_binding
       hci_core_assign i_ext_assign (
         .tcdm_target    ( ext             [ii]        ),
         .tcdm_initiator ( all_except_hwpe [N_CORE+ii] )
       );
-    end // ext_binding
+    end : ext_binding
     for(genvar ii=0; ii<N_DMA; ii++) begin: dma_binding
       hci_core_assign i_dma_assign (
         .tcdm_target    ( dma             [ii]              ),
         .tcdm_initiator ( all_except_hwpe [N_CORE+N_EXT+ii] )
       );
-    end // dma_binding
+    end : dma_binding
   endgenerate
 
 /*

--- a/rtl/hci_interconnect.sv
+++ b/rtl/hci_interconnect.sv
@@ -62,6 +62,7 @@ module hci_interconnect
   parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
   parameter int unsigned EXPFIFO = 0                        , // FIFO Depth for HWPE Interconnect
   parameter int unsigned SEL_LIC = 0                        , // Log interconnect type selector
+  parameter int unsigned HCI_CUT = 0                        , //
   parameter int unsigned FILTER_WRITE_R_VALID[0:N_HWPE-1] = '{default: 0},
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(cores) = '0,
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(mems)  = '0,
@@ -294,10 +295,22 @@ module hci_interconnect
 
   generate
     for(genvar ii=0; ii<N_CORE; ii++) begin: cores_binding
-      hci_core_assign i_cores_assign (
-        .tcdm_target    ( cores           [ii] ),
-        .tcdm_initiator ( all_except_hwpe [ii] )
-      );
+      if (HCI_CUT) begin : hci_cut
+        hci_core_cut #(
+        .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
+        ) i_hci_cut (
+            .clk_i  ( clk_i                ),
+            .rst_ni ( rst_ni               ),
+            .in     ( cores           [ii] ),
+            .out    ( all_except_hwpe [ii] )
+        );
+      end
+      else begin : no_hci_cut
+        hci_core_assign i_cores_assign (
+          .tcdm_target    ( cores           [ii] ),
+          .tcdm_initiator ( all_except_hwpe [ii] )
+        );
+      end
     end : cores_binding
     for(genvar ii=0; ii<N_EXT; ii++) begin: ext_binding
       hci_core_assign i_ext_assign (

--- a/rtl/hci_interconnect.sv
+++ b/rtl/hci_interconnect.sv
@@ -75,11 +75,11 @@ module hci_interconnect
   input logic                   rst_ni              ,
   input logic                   clear_i             ,
   input hci_interconnect_ctrl_t ctrl_i              ,
-  hci_core_intf.target           cores   [0:N_CORE-1],
-  hci_core_intf.target           dma     [0:N_DMA-1] ,
-  hci_core_intf.target           ext     [0:N_EXT-1] ,
-  hci_core_intf.initiator        mems    [0:N_MEM-1] ,
-  hci_core_intf.target           hwpe    [0:N_HWPE-1]
+  hci_core_intf.target           cores [0:hci_package::iomsb(N_CORE)],
+  hci_core_intf.target           dma   [0:hci_package::iomsb(N_DMA)] ,
+  hci_core_intf.target           ext   [0:hci_package::iomsb(N_EXT)] ,
+  hci_core_intf.initiator        mems  [0:hci_package::iomsb(N_MEM)] ,
+  hci_core_intf.target           hwpe  [0:hci_package::iomsb(N_HWPE)]
 );
 
   localparam int unsigned AWC = `HCI_SIZE_GET_AW(cores);

--- a/rtl/hci_interconnect.sv
+++ b/rtl/hci_interconnect.sv
@@ -53,16 +53,18 @@
 module hci_interconnect
   import hci_package::*;
 #(
-  parameter int unsigned N_HWPE  = 1                        , // Number of HWPEs attached to the port
-  parameter int unsigned N_CORE  = 8                        , // Number of Core ports
-  parameter int unsigned N_DMA   = 4                        , // Number of DMA ports
-  parameter int unsigned N_EXT   = 4                        , // Number of External ports
-  parameter int unsigned N_MEM   = 16                       , // Number of Memory banks
-  parameter int unsigned TS_BIT  = 21                       , // TEST_SET_BIT (for Log Interconnect)
-  parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
-  parameter int unsigned EXPFIFO = 0                        , // FIFO Depth for HWPE Interconnect
-  parameter int unsigned SEL_LIC = 0                        , // Log interconnect type selector
-  parameter int unsigned HCI_CUT = 0                        , //
+  parameter int unsigned N_HWPE    = 1                        , // Number of HWPEs attached to the port
+  parameter int unsigned N_CORE    = 8                        , // Number of Core ports
+  parameter int unsigned N_DMA     = 4                        , // Number of DMA ports
+  parameter int unsigned N_EXT     = 4                        , // Number of External ports
+  parameter int unsigned N_MEM     = 16                       , // Number of Memory banks
+  parameter int unsigned TS_BIT    = 21                       , // TEST_SET_BIT (for Log Interconnect)
+  parameter int unsigned IW        = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
+  parameter int unsigned EXPFIFO   = 0                        , // FIFO Depth for HWPE Interconnect
+  parameter int unsigned SEL_LIC   = 0                        , // Log interconnect type selector
+  parameter int unsigned CUT_CORES = 0                        , // Insert a cut in cores interconnect
+  parameter int unsigned CUT_IDMA  = 0                        , // Insert a cut in Idma interconnect
+  parameter int unsigned CUT_EXT   = 0                        , // Insert a cut in EXT interconnect
   parameter int unsigned FILTER_WRITE_R_VALID[0:N_HWPE-1] = '{default: 0},
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(cores) = '0,
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(mems)  = '0,
@@ -295,7 +297,7 @@ module hci_interconnect
 
   generate
     for(genvar ii=0; ii<N_CORE; ii++) begin: cores_binding
-      if (HCI_CUT) begin : hci_cut
+      if (CUT_CORES) begin : hci_cut
         hci_core_cut #(
         .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
         ) i_hci_cut (
@@ -313,16 +315,40 @@ module hci_interconnect
       end
     end : cores_binding
     for(genvar ii=0; ii<N_EXT; ii++) begin: ext_binding
+      if (CUT_IDMA) begin : hci_cut
+          hci_core_cut #(
+          .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
+          ) i_hci_cut (
+              .clk_i  ( clk_i                ),
+              .rst_ni ( rst_ni               ),
+              .in     ( ext             [ii] ),
+              .out    ( all_except_hwpe [N_CORE+ii] )
+          );
+      end 
+      else begin : no_hci_cut
       hci_core_assign i_ext_assign (
         .tcdm_target    ( ext             [ii]        ),
         .tcdm_initiator ( all_except_hwpe [N_CORE+ii] )
       );
-    end : ext_binding
+      end
+    end : ext_binding 
     for(genvar ii=0; ii<N_DMA; ii++) begin: dma_binding
-      hci_core_assign i_dma_assign (
-        .tcdm_target    ( dma             [ii]              ),
-        .tcdm_initiator ( all_except_hwpe [N_CORE+N_EXT+ii] )
-      );
+      if (CUT_EXT) begin : hci_cut
+          hci_core_cut #(
+          .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
+          ) i_hci_cut (
+              .clk_i  ( clk_i                ),
+              .rst_ni ( rst_ni               ),
+              .in     ( dma             [ii] ),
+              .out    ( all_except_hwpe [N_CORE+N_EXT+ii] )
+          );
+      end 
+      else begin : no_hci_cut
+        hci_core_assign i_dma_assign (
+          .tcdm_target    ( dma             [ii]              ),
+          .tcdm_initiator ( all_except_hwpe [N_CORE+N_EXT+ii] )
+        );
+      end
     end : dma_binding
   endgenerate
 

--- a/rtl/hci_interconnect.sv
+++ b/rtl/hci_interconnect.sv
@@ -62,6 +62,7 @@ module hci_interconnect
   parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
   parameter int unsigned EXPFIFO = 0                        , // FIFO Depth for HWPE Interconnect
   parameter int unsigned SEL_LIC = 0                        , // Log interconnect type selector
+  parameter int unsigned HCI_CUT = 0                        , //
   parameter int unsigned FILTER_WRITE_R_VALID[0:N_HWPE-1] = '{default: 0},
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(cores) = '0,
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(mems)  = '0,
@@ -324,10 +325,22 @@ module hci_interconnect
 
   generate
     for(genvar ii=0; ii<N_CORE; ii++) begin: cores_binding
-      hci_core_assign i_cores_assign (
-        .tcdm_target    ( cores           [ii] ),
-        .tcdm_initiator ( all_except_hwpe [ii] )
-      );
+      if (HCI_CUT) begin : hci_cut
+        hci_core_cut #(
+        .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
+        ) i_hci_cut (
+            .clk_i  ( clk_i                ),
+            .rst_ni ( rst_ni               ),
+            .in     ( cores           [ii] ),
+            .out    ( all_except_hwpe [ii] )
+        );
+      end
+      else begin : no_hci_cut
+        hci_core_assign i_cores_assign (
+          .tcdm_target    ( cores           [ii] ),
+          .tcdm_initiator ( all_except_hwpe [ii] )
+        );
+      end
     end : cores_binding
     for(genvar ii=0; ii<N_EXT; ii++) begin: ext_binding
       hci_core_assign i_ext_assign (

--- a/rtl/hci_interconnect.sv
+++ b/rtl/hci_interconnect.sv
@@ -53,16 +53,18 @@
 module hci_interconnect
   import hci_package::*;
 #(
-  parameter int unsigned N_HWPE  = 1                        , // Number of HWPEs attached to the port
-  parameter int unsigned N_CORE  = 8                        , // Number of Core ports
-  parameter int unsigned N_DMA   = 4                        , // Number of DMA ports
-  parameter int unsigned N_EXT   = 4                        , // Number of External ports
-  parameter int unsigned N_MEM   = 16                       , // Number of Memory banks
-  parameter int unsigned TS_BIT  = 21                       , // TEST_SET_BIT (for Log Interconnect)
-  parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
-  parameter int unsigned EXPFIFO = 0                        , // FIFO Depth for HWPE Interconnect
-  parameter int unsigned SEL_LIC = 0                        , // Log interconnect type selector
-  parameter int unsigned HCI_CUT = 0                        , //
+  parameter int unsigned N_HWPE    = 1                        , // Number of HWPEs attached to the port
+  parameter int unsigned N_CORE    = 8                        , // Number of Core ports
+  parameter int unsigned N_DMA     = 4                        , // Number of DMA ports
+  parameter int unsigned N_EXT     = 4                        , // Number of External ports
+  parameter int unsigned N_MEM     = 16                       , // Number of Memory banks
+  parameter int unsigned TS_BIT    = 21                       , // TEST_SET_BIT (for Log Interconnect)
+  parameter int unsigned IW        = N_HWPE+N_CORE+N_DMA+N_EXT, // ID Width
+  parameter int unsigned EXPFIFO   = 0                        , // FIFO Depth for HWPE Interconnect
+  parameter int unsigned SEL_LIC   = 0                        , // Log interconnect type selector
+  parameter int unsigned CUT_CORES = 0                        , // Insert a cut in cores interconnect
+  parameter int unsigned CUT_IDMA  = 0                        , // Insert a cut in Idma interconnect
+  parameter int unsigned CUT_EXT   = 0                        , // Insert a cut in EXT interconnect
   parameter int unsigned FILTER_WRITE_R_VALID[0:N_HWPE-1] = '{default: 0},
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(cores) = '0,
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(mems)  = '0,
@@ -325,7 +327,7 @@ module hci_interconnect
 
   generate
     for(genvar ii=0; ii<N_CORE; ii++) begin: cores_binding
-      if (HCI_CUT) begin : hci_cut
+      if (CUT_CORES) begin : hci_cut
         hci_core_cut #(
         .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
         ) i_hci_cut (
@@ -343,16 +345,40 @@ module hci_interconnect
       end
     end : cores_binding
     for(genvar ii=0; ii<N_EXT; ii++) begin: ext_binding
+      if (CUT_IDMA) begin : hci_cut
+          hci_core_cut #(
+          .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
+          ) i_hci_cut (
+              .clk_i  ( clk_i                ),
+              .rst_ni ( rst_ni               ),
+              .in     ( ext             [ii] ),
+              .out    ( all_except_hwpe [N_CORE+ii] )
+          );
+      end 
+      else begin : no_hci_cut
       hci_core_assign i_ext_assign (
         .tcdm_target    ( ext             [ii]        ),
         .tcdm_initiator ( all_except_hwpe [N_CORE+ii] )
       );
-    end : ext_binding
+      end
+    end : ext_binding 
     for(genvar ii=0; ii<N_DMA; ii++) begin: dma_binding
-      hci_core_assign i_dma_assign (
-        .tcdm_target    ( dma             [ii]              ),
-        .tcdm_initiator ( all_except_hwpe [N_CORE+N_EXT+ii] )
-      );
+      if (CUT_EXT) begin : hci_cut
+          hci_core_cut #(
+          .`HCI_SIZE_PARAM(in)(`HCI_SIZE_PARAM(cores))
+          ) i_hci_cut (
+              .clk_i  ( clk_i                ),
+              .rst_ni ( rst_ni               ),
+              .in     ( dma             [ii] ),
+              .out    ( all_except_hwpe [N_CORE+N_EXT+ii] )
+          );
+      end 
+      else begin : no_hci_cut
+        hci_core_assign i_dma_assign (
+          .tcdm_target    ( dma             [ii]              ),
+          .tcdm_initiator ( all_except_hwpe [N_CORE+N_EXT+ii] )
+        );
+      end
     end : dma_binding
   endgenerate
 

--- a/target/verif/src/tb_hci.sv
+++ b/target/verif/src/tb_hci.sv
@@ -81,7 +81,7 @@ module tb_hci
     .IW(HCI_SIZE_cores.IW),
     .EW(HCI_SIZE_cores.EW),
     .EHW(HCI_SIZE_cores.EHW)
-  ) hci_driver_log_if [0:N_LOG_MASTERS-1] (
+  ) hci_driver_log_if [0:hci_package::iomsb(N_LOG_MASTERS)] (
     .clk(clk)
   );
 
@@ -93,7 +93,7 @@ module tb_hci
     .IW(HCI_SIZE_hwpe.IW),
     .EW(HCI_SIZE_hwpe.EW),
     .EHW(HCI_SIZE_hwpe.EHW)
-  ) hci_driver_hwpe_if [0:N_HWPE-1] (
+  ) hci_driver_hwpe_if [0:hci_package::iomsb(N_HWPE)] (
     .clk(clk)
   );
 
@@ -107,7 +107,7 @@ module tb_hci
     .IW(HCI_SIZE_cores.IW),
     .EW(HCI_SIZE_cores.EW),
     .EHW(HCI_SIZE_cores.EHW)
-  ) hci_initiator_narrow [0:N_NARROW_HCI-1] (
+  ) hci_initiator_narrow [0:hci_package::iomsb(N_NARROW_HCI)] (
     .clk(clk)
   );
 
@@ -119,7 +119,7 @@ module tb_hci
     .IW(HCI_SIZE_hwpe.IW),
     .EW(HCI_SIZE_hwpe.EW),
     .EHW(HCI_SIZE_hwpe.EHW)
-  ) hci_initiator_wide [0:N_WIDE_HCI-1] (
+  ) hci_initiator_wide [0:hci_package::iomsb(N_WIDE_HCI)] (
     .clk(clk)
   );
 
@@ -131,7 +131,7 @@ module tb_hci
     .IW(HCI_SIZE_cores.IW),
     .EW(HCI_SIZE_cores.EW),
     .EHW(HCI_SIZE_cores.EHW)
-  ) hci_initiator_dma [0:N_DMA-1] (
+  ) hci_initiator_dma [0:hci_package::iomsb(N_DMA)] (
     .clk(clk)
   );
 
@@ -143,7 +143,7 @@ module tb_hci
     .IW(HCI_SIZE_cores.IW),
     .EW(HCI_SIZE_cores.EW),
     .EHW(HCI_SIZE_cores.EHW)
-  ) hci_initiator_ext [0:N_EXT-1] (
+  ) hci_initiator_ext [0:hci_package::iomsb(N_EXT)] (
     .clk(clk)
   );
 
@@ -159,7 +159,7 @@ module tb_hci
     .WAIVE_RQ4_ASSERT(1'b1),
     .WAIVE_RSP3_ASSERT(1'b1),
     .WAIVE_RSP5_ASSERT(1'b1)
-  ) hci_target_mems [0:N_BANKS-1] (
+  ) hci_target_mems [0:hci_package::iomsb(N_BANKS)] (
     .clk(clk)
   );
 


### PR DESCRIPTION
Adding of hci cuts for idma,ext and cores:
The parameters CUT_CORES, CUT_IDMA and CUT_EXT set to 1 permits to add cuts in the rtl/ecc/hci_ecc_interconnect.sv and rtl/hci_interconnect.sv . 
