### PR TITLE
Fix timeunit for VCS

### DIFF
--- a/target/verif/src/tb_hci.sv
+++ b/target/verif/src/tb_hci.sv
@@ -18,9 +18,6 @@
 
 `include "hci_helpers.svh"
 
-timeunit 1ns;
-timeprecision 10ps;
-
 module tb_hci
   import hci_package::*;
   import tb_hci_pkg::*;


### PR DESCRIPTION
While preparing a VCS flow for teh Gwaihir project, I encountered the problem that this TB is setting a timescale which differs from the one specified in the options passed to the gwihir simulation flow. 

VCS is quite strict on this.

I would suggest to remove it similarly to what has been done in [common_verification](https://github.com/pulp-platform/common_verification/blob/c5d97a1fae01d2d8e8e311dee341b6b8849dcf38/CHANGELOG.md?plain=1#L54).