### PR TITLE
tentative CI fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,9 @@ variables:
 before_script:
   - python -V  # Print out python version for debugging
   - python -m pip install --user virtualenv
+  - python -m virtualenv .venv
+  - source .venv/bin/activate
+  - PIP_USER=0 pip install junit_xml pyyaml prettytable
 
 .base:
   artifacts:

--- a/regr/bwruntests.py
+++ b/regr/bwruntests.py
@@ -239,6 +239,10 @@ def poolInit(s, t, l):
     lock = l
 
 if __name__ == '__main__':
+    # Python 3.14 changed the default multiprocessing start method on Linux
+    # from 'fork' to 'forkserver'. Workers below rely on inheriting `args` and
+    # other module-level state via fork's copy-on-write memory, so force it.
+    multiprocessing.set_start_method('fork')
     args = runtest.parse_args()
     pp = pprint.PrettyPrinter(indent=4)
 


### PR DESCRIPTION
This pull request updates the CI pipeline to use a Python virtual environment and installs additional dependencies before running jobs. The main change is to ensure a clean and isolated Python environment for CI tasks.

Environment setup improvements:

* The `before_script` section in `.gitlab-ci.yml` now creates and activates a Python virtual environment using `virtualenv`, and installs the `junit_xml`, `pyyaml`, and `prettytable` packages to ensure required dependencies are available in an isolated environment.