### PR TITLE
[source] fix a corner case highlighted in RedMulE for misaligned access

### DIFF
--- a/rtl/core/hci_core_source.sv
+++ b/rtl/core/hci_core_source.sv
@@ -235,7 +235,7 @@ module hci_core_source
     else
       assign addr_misaligned_push.data  = {{(ADDR_OFFSET_BYTE-ADDR_OFFSET){1'b0}}, addr_pop.data[ADDR_OFFSET-1:0]};
     assign addr_misaligned_push.strb  = '1;
-    assign addr_misaligned_push.valid = enable_i & tcdm.gnt; // BEWARE: considered always ready!!!
+    assign addr_misaligned_push.valid = enable_i & tcdm.req & tcdm.gnt; // check full handshake (req&gnt): hci_core_fifo plugs gnt to a ready, therefore gnt's may be asserted without a related req. BEWARE: pop considered always ready!!!
     assign addr_misaligned_pop.ready  = (tcdm.r_valid | stream_valid_q) & resp_push.ready;
     assign addr_misaligned_q = addr_misaligned_pop.data[ADDR_OFFSET-1:0];
 

--- a/rtl/core/hci_core_source_v2.sv
+++ b/rtl/core/hci_core_source_v2.sv
@@ -294,7 +294,7 @@ module hci_core_source_v2
   );
   assign addr_misaligned_push.data  = {6'b0, addr_pop.data[1:0]};
   assign addr_misaligned_push.strb  = '1;
-  assign addr_misaligned_push.valid = enable_i & tcdm.req & tcdm.gnt; // BEWARE: considered always ready!!!
+  assign addr_misaligned_push.valid = enable_i & tcdm.req & tcdm.gnt; // check full handshake (req&gnt): hci_core_fifo plugs gnt to a ready, therefore gnt's may be asserted without a related req. BEWARE: pop considered always ready!!!
   assign addr_misaligned_pop.ready  = (tcdm.r_valid | stream_valid_q) & stream.ready;
   assign addr_misaligned_q = addr_misaligned_pop.data[1:0];
 


### PR DESCRIPTION
In some corner case, visible in RedMulE before this fix, spurious gnt's without a related req may be back-propagated from hci_core_fifo to the addr_misaligned fifo in hci_core_source. This causes phantom address transactions to propagate.